### PR TITLE
Feat: ArgumentResolver 활용하여 인증 객체 책임 분리

### DIFF
--- a/src/main/java/com/eggmeonina/scrumble/common/resolver/MemberArgumentResolver.java
+++ b/src/main/java/com/eggmeonina/scrumble/common/resolver/MemberArgumentResolver.java
@@ -7,26 +7,30 @@ import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.method.support.ModelAndViewContainer;
 
 import com.eggmeonina.scrumble.common.anotation.Member;
+import com.eggmeonina.scrumble.domain.auth.dto.LoginMember;
 import com.eggmeonina.scrumble.domain.member.domain.SessionKey;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpSession;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 public class MemberArgumentResolver implements HandlerMethodArgumentResolver {
 	@Override
 	public boolean supportsParameter(MethodParameter parameter) {
+		log.info("supportsParameter 실행");
 		boolean hasMemberAnnotation = parameter.hasParameterAnnotation(Member.class);
-		boolean hasLoginUserType = Member.class.isAssignableFrom(parameter.getParameterType());
+		boolean hasLoginUserType = LoginMember.class.isAssignableFrom(parameter.getParameterType());
 		return hasMemberAnnotation && hasLoginUserType;
 	}
 
 	@Override
 	public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
-		NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
+		NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
 		HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
 		HttpSession session = request.getSession(false);
 		if (session == null) {
-			return null;
+			throw new RuntimeException("로그인하지 않은 회원입니다.");
 		}
 		return session.getAttribute(SessionKey.LOGIN_USER.name());
 	}

--- a/src/test/java/com/eggmeonina/scrumble/common/resolver/MemberArgumentResolverTest.java
+++ b/src/test/java/com/eggmeonina/scrumble/common/resolver/MemberArgumentResolverTest.java
@@ -1,0 +1,132 @@
+package com.eggmeonina.scrumble.common.resolver;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.BDDAssertions.*;
+import static org.assertj.core.api.SoftAssertions.*;
+import static org.mockito.BDDMockito.*;
+
+import java.lang.reflect.Method;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.core.MethodParameter;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpSession;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+
+import com.eggmeonina.scrumble.common.anotation.Member;
+import com.eggmeonina.scrumble.domain.auth.dto.LoginMember;
+import com.eggmeonina.scrumble.domain.member.domain.SessionKey;
+
+@ExtendWith(MockitoExtension.class)
+class MemberArgumentResolverTest {
+
+	private HandlerMethodArgumentResolver memberArgumentResolver;
+	private Class<?> clazz;
+
+	private NativeWebRequest webRequest;
+	@BeforeEach
+	void setUp() {
+		memberArgumentResolver = new MemberArgumentResolver();
+		clazz = ArgumentResolverTest.class;
+		webRequest = Mockito.mock();
+	}
+
+	@Test
+	@DisplayName("Member 어노테이션이 선언되어 있고 LoginMember 객체를 사용하면 true를 반환한다")
+	void supportsParameter_success_returnTrue() throws NoSuchMethodException {
+		// given
+		MethodParameter methodParameter = getMethodParameter("hasAnnotationAndObject", LoginMember.class);
+
+		// when
+		boolean actual = memberArgumentResolver.supportsParameter(methodParameter);
+
+		// then
+		assertThat(actual).isTrue();
+	}
+
+	@Test
+	@DisplayName("Member 어노테이션만 선언되어 있으면 false를 반환한다")
+	void supportsParameter_fail_returnFalse() throws NoSuchMethodException {
+		// given
+		MethodParameter methodParameter = getMethodParameter("hasAnnotationWithoutLoginMember", Object.class);
+
+		// when
+		boolean actual = memberArgumentResolver.supportsParameter(methodParameter);
+
+		// then
+		assertThat(actual).isFalse();
+	}
+
+	@Test
+	@DisplayName("LoginMember 객체만 선언되어 있으면 false를 반환한다")
+	void supportsParameterWithoutAnnotation_fail_returnFalse() throws NoSuchMethodException {
+		// given
+		MethodParameter methodParameter = getMethodParameter("hasLoginMemberWithoutAnnotation", LoginMember.class);
+
+		// when
+		boolean actual = memberArgumentResolver.supportsParameter(methodParameter);
+
+		// then
+		assertThat(actual).isFalse();
+	}
+
+	@Test
+	@DisplayName("세션 데이터가 있으면 객체를 반환한다")
+	void resolveArgument_success_returnsObject() throws Exception {
+		// given
+		// MockHttpSession 생성
+		LoginMember loginMember = new LoginMember(1L, "testUser@test.com", "testA");
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		MockHttpSession session = new MockHttpSession();
+		request.setSession(session); // 요청에 세션 설정
+		session.setAttribute(SessionKey.LOGIN_USER.name(), loginMember);
+
+		given(webRequest.getNativeRequest()).willReturn(request);
+
+
+		// when
+		LoginMember response
+			= (LoginMember)memberArgumentResolver.resolveArgument(null, null, webRequest, null);
+
+		// then
+		assertSoftly(softly -> {
+			softly.assertThat(response.getMemberId()).isEqualTo(loginMember.getMemberId());
+			softly.assertThat(response.getEmail()).isEqualTo(loginMember.getEmail());
+			softly.assertThat(response.getName()).isEqualTo(loginMember.getName());
+		});
+	}
+
+	@Test
+	@DisplayName("세션 데이터가 없으면 예외를 발생시킨다")
+	void resolveArgument_fail_throwsException() {
+		// given
+		// MockHttpSession 생성
+		MockHttpServletRequest request = new MockHttpServletRequest();
+
+		given(webRequest.getNativeRequest()).willReturn(request);
+
+
+		// when, then
+		thenThrownBy(
+			()-> memberArgumentResolver.resolveArgument(null, null, webRequest, null))
+			.isInstanceOf(RuntimeException.class);
+	}
+
+	private MethodParameter getMethodParameter(String methodName, Class<?> parameter) throws NoSuchMethodException {
+		Method hasAnnotationAndObject = clazz.getDeclaredMethod(methodName, parameter);
+		return new MethodParameter(hasAnnotationAndObject, 0);
+	}
+
+	public static class ArgumentResolverTest{
+		public void hasAnnotationAndObject(@Member LoginMember member){}
+		public void hasAnnotationWithoutLoginMember(@Member Object member){}
+		public void hasLoginMemberWithoutAnnotation(LoginMember member){ }
+	}
+
+}


### PR DESCRIPTION
## 관련 이슈
#28 

## 작업 사항
`ArgumentResolver`를 활용하여 세션에 저장된 로그인 객체를 바인딩할 수 있도록 변경하였습니다.