### PR TITLE
Feat: 나의 스쿼드 리스트 조회 기능 개발

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,9 +54,9 @@ def generated = 'src/main/generated'
 tasks.withType(JavaCompile).configureEach {
 	options.generatedSourceOutputDirectory = file(generated)
 }
-sourceSets {main.java.srcDirs += "$projectDir/build/generated"}
+sourceSets {main.java.srcDirs += "$projectDir/src/main/generated"}
 
-clean {	delete file('src/main/generated')}
+clean {	delete file(generated)}
 
 dependencyManagement {
 	imports {

--- a/src/main/java/com/eggmeonina/scrumble/domain/membership/controller/SquadController.java
+++ b/src/main/java/com/eggmeonina/scrumble/domain/membership/controller/SquadController.java
@@ -1,8 +1,10 @@
 package com.eggmeonina.scrumble.domain.membership.controller;
 
+import java.util.List;
 import java.util.Map;
 
 import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -12,7 +14,9 @@ import com.eggmeonina.scrumble.common.anotation.Member;
 import com.eggmeonina.scrumble.common.domain.ApiResponse;
 import com.eggmeonina.scrumble.domain.auth.dto.LoginMember;
 import com.eggmeonina.scrumble.domain.membership.dto.SquadCreateRequest;
+import com.eggmeonina.scrumble.domain.membership.dto.SquadResponse;
 import com.eggmeonina.scrumble.domain.membership.facade.MembershipFacadeService;
+import com.eggmeonina.scrumble.domain.membership.service.MembershipService;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -27,6 +31,7 @@ import lombok.RequiredArgsConstructor;
 public class SquadController {
 
 	private final MembershipFacadeService membershipFacadeService;
+	private final MembershipService membershipService;
 
 	@PostMapping
 	@Operation(summary = "스쿼드를 생성한다", description = "스쿼드를 생성하면서 스쿼드장을 같이 생성한다.")
@@ -37,5 +42,14 @@ public class SquadController {
 		Long squadId = membershipFacadeService.createSquad(member.getMemberId(), request);
 		return ApiResponse.createSuccessResponse(HttpStatus.CREATED.value(), Map.of("squadId", squadId));
 	}
+
+	@GetMapping
+	@Operation(summary = "나의 스쿼드를 조회한다", description = "내가 속해있는 스쿼드들을 조회한다.")
+	public ApiResponse<List<SquadResponse>> findSquads(
+		@Parameter(hidden = true) @Member LoginMember member
+	) {
+		return ApiResponse.createSuccessResponse(HttpStatus.OK.value(), membershipService.findBySquads(member.getMemberId()));
+	}
+
 
 }

--- a/src/main/java/com/eggmeonina/scrumble/domain/membership/dto/SquadResponse.java
+++ b/src/main/java/com/eggmeonina/scrumble/domain/membership/dto/SquadResponse.java
@@ -1,0 +1,19 @@
+package com.eggmeonina.scrumble.domain.membership.dto;
+
+import com.querydsl.core.annotations.QueryProjection;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class SquadResponse {
+	private Long squadId;
+	private String squadName;
+
+	@QueryProjection
+	public SquadResponse(Long squadId, String squadName) {
+		this.squadId = squadId;
+		this.squadName = squadName;
+	}
+}

--- a/src/main/java/com/eggmeonina/scrumble/domain/membership/repository/MembershipRepository.java
+++ b/src/main/java/com/eggmeonina/scrumble/domain/membership/repository/MembershipRepository.java
@@ -8,7 +8,7 @@ import org.springframework.stereotype.Repository;
 import com.eggmeonina.scrumble.domain.membership.domain.Membership;
 
 @Repository
-public interface MembershipRepository extends JpaRepository<Membership,Long> {
+public interface MembershipRepository extends JpaRepository<Membership,Long>, MembershipRepositoryCustom {
 
 	Optional<Membership> findByMemberIdAndSquadId(final Long memberId, final Long squadId);
 }

--- a/src/main/java/com/eggmeonina/scrumble/domain/membership/repository/MembershipRepositoryCustom.java
+++ b/src/main/java/com/eggmeonina/scrumble/domain/membership/repository/MembershipRepositoryCustom.java
@@ -1,0 +1,10 @@
+package com.eggmeonina.scrumble.domain.membership.repository;
+
+import java.util.List;
+
+import com.eggmeonina.scrumble.domain.membership.dto.SquadResponse;
+
+public interface MembershipRepositoryCustom {
+
+	List<SquadResponse> findSquads(Long memberId);
+}

--- a/src/main/java/com/eggmeonina/scrumble/domain/membership/repository/impl/MembershipRepositoryImpl.java
+++ b/src/main/java/com/eggmeonina/scrumble/domain/membership/repository/impl/MembershipRepositoryImpl.java
@@ -1,0 +1,37 @@
+package com.eggmeonina.scrumble.domain.membership.repository.impl;
+
+import static com.eggmeonina.scrumble.domain.membership.domain.QMembership.*;
+
+import java.util.List;
+
+import org.springframework.stereotype.Repository;
+
+import com.eggmeonina.scrumble.domain.membership.domain.MembershipStatus;
+import com.eggmeonina.scrumble.domain.membership.dto.QSquadResponse;
+import com.eggmeonina.scrumble.domain.membership.dto.SquadResponse;
+import com.eggmeonina.scrumble.domain.membership.repository.MembershipRepositoryCustom;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class MembershipRepositoryImpl implements MembershipRepositoryCustom {
+
+	private final JPAQueryFactory query;
+
+	@Override
+	public List<SquadResponse> findSquads(Long memberId) {
+		// TODO : createAt desc 기준으로 index 생성하기
+		return
+			query.select(
+					new QSquadResponse(membership.squad.id, membership.squad.squadName))
+				.from(membership)
+				.join(membership.squad)
+				.where(membership.member.id.eq(memberId).
+					and(membership.membershipStatus.eq(MembershipStatus.JOIN)).
+					and(membership.squad.deletedFlag.eq(false))
+				)
+				.fetch();
+	}
+}

--- a/src/main/java/com/eggmeonina/scrumble/domain/membership/service/MembershipService.java
+++ b/src/main/java/com/eggmeonina/scrumble/domain/membership/service/MembershipService.java
@@ -2,6 +2,8 @@ package com.eggmeonina.scrumble.domain.membership.service;
 
 import static com.eggmeonina.scrumble.common.exception.ErrorCode.*;
 
+import java.util.List;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -13,6 +15,7 @@ import com.eggmeonina.scrumble.domain.membership.domain.Membership;
 import com.eggmeonina.scrumble.domain.membership.domain.MembershipRole;
 import com.eggmeonina.scrumble.domain.membership.domain.MembershipStatus;
 import com.eggmeonina.scrumble.domain.membership.domain.Squad;
+import com.eggmeonina.scrumble.domain.membership.dto.SquadResponse;
 import com.eggmeonina.scrumble.domain.membership.repository.SquadRepository;
 import com.eggmeonina.scrumble.domain.membership.repository.MembershipRepository;
 
@@ -43,5 +46,9 @@ public class MembershipService {
 			.build();
 		membershipRepository.save(newMembership);
 		return newMembership.getId();
+	}
+
+	public List<SquadResponse> findBySquads(Long memberId){
+		return membershipRepository.findSquads(memberId);
 	}
 }

--- a/src/main/resources/db/h2/data.sql
+++ b/src/main/resources/db/h2/data.sql
@@ -1,2 +1,6 @@
 insert into member (member_id, email, name, member_status, oauth_type) values (default, 'testA@email.com', 'testA', 'JOIN', 'GOOGLE');
 insert into member (member_id, email, name, member_status, oauth_type) values (default, 'scrumble@email.com', 'scrumble', 'JOIN', 'GOOGLE');
+
+insert into squad (squad_id, squad_name, deleted_flag, created_at) values ( default, '테스트 스쿼드', false, now());
+
+insert into membership(membership_id, member_id, squad_id, membership_role, membership_status, created_at) values ( default, 1L, 1L, 'LEADER', 'JOIN', now());

--- a/src/main/resources/db/mysql/data.sql
+++ b/src/main/resources/db/mysql/data.sql
@@ -1,2 +1,6 @@
 insert into member (member_id, email, name, member_status, oauth_type) values (default, 'testA@email.com', 'testA', 'JOIN', 'GOOGLE');
 insert into member (member_id, email, name, member_status, oauth_type) values (default, 'scrumble@email.com', 'scrumble', 'JOIN', 'GOOGLE');
+
+insert into squad (squad_id, squad_name, deleted_flag, created_at) values ( default, '테스트 스쿼드', false, now());
+
+insert into membership(membership_id, member_id, squad_id, membership_role, membership_status, created_at) values ( default, 1L, 1L, 'LEADER', 'JOIN', now());


### PR DESCRIPTION
## 관련 이슈
#35 

## 작업 사항
<!-- 가장 대표적인 작업 내용 -->
나의 스쿼드 리스트를 조회합니다.
- join(가입) 상태인 스쿼드만 조회합니다.
- 삭제 되지 않은 스쿼드만 조회합니다.
- 내가 속해있는 스쿼드의 id, name을 조회합니다.

### 추가 정보
<!-- 이 PR에 대한 추가적인 정보가 필요하다면 작성해주세요. -->
