### PR TITLE
Feat: 스쿼드 탈퇴 기능 개발

### DIFF
--- a/src/main/java/com/eggmeonina/scrumble/common/exception/ErrorCode.java
+++ b/src/main/java/com/eggmeonina/scrumble/common/exception/ErrorCode.java
@@ -33,7 +33,8 @@ public enum ErrorCode {
 	MEMBER_OR_SQUAD_NOT_FOUND(HttpStatus.BAD_REQUEST, "회원 또는 스쿼드가 존재하지 않습니다."),
 	SQUAD_NOT_FOUND(HttpStatus.BAD_REQUEST, "스쿼드가 존재하지 않습니다."),
 	SQUADMEMBER_NOT_FOUND(HttpStatus.BAD_REQUEST, "스쿼드에 존재하는 회원이 아닙니다."),
-	UNAUTHORIZED_ACTION(HttpStatus.FORBIDDEN, "권한이 없는 사용자입니다.");
+	UNAUTHORIZED_ACTION(HttpStatus.FORBIDDEN, "권한이 없는 사용자입니다."),
+	LEADER_CANNOT_LEAVE(HttpStatus.FORBIDDEN, "스쿼드 리더는 탈퇴가 불가능합니다.");
 
 	private final HttpStatus status;
 	private final String message;

--- a/src/main/java/com/eggmeonina/scrumble/domain/squadmember/domain/SquadMember.java
+++ b/src/main/java/com/eggmeonina/scrumble/domain/squadmember/domain/SquadMember.java
@@ -73,4 +73,8 @@ public class SquadMember extends BaseEntity {
 		}
 		this.squadMemberRole = SquadMemberRole.NORMAL;
 	}
+
+	public void leave() {
+		this.squadMemberStatus = SquadMemberStatus.LEAVE;
+	}
 }

--- a/src/main/java/com/eggmeonina/scrumble/domain/squadmember/domain/SquadMemberStatus.java
+++ b/src/main/java/com/eggmeonina/scrumble/domain/squadmember/domain/SquadMemberStatus.java
@@ -8,7 +8,7 @@ import lombok.RequiredArgsConstructor;
 public enum SquadMemberStatus {
 	INVITING("초대 중"),
 	JOIN("가입"),
-	WITHDRAW("탈퇴"),
+	LEAVE("탈퇴"),
 	CANCEL("초대 취소");
 
 	private final String desc;

--- a/src/main/java/com/eggmeonina/scrumble/domain/squadmember/repository/SquadMemberRepositoryCustom.java
+++ b/src/main/java/com/eggmeonina/scrumble/domain/squadmember/repository/SquadMemberRepositoryCustom.java
@@ -6,5 +6,7 @@ import com.eggmeonina.scrumble.domain.squadmember.dto.SquadResponse;
 
 public interface SquadMemberRepositoryCustom {
 
-	List<SquadResponse> findSquads(Long memberId);
+	List<SquadResponse> findSquads(final Long memberId);
+
+	boolean existsBySquadMemberNotMemberId(final Long squadId, final Long memberId);
 }

--- a/src/main/java/com/eggmeonina/scrumble/domain/squadmember/repository/impl/SquadMemberRepositoryImpl.java
+++ b/src/main/java/com/eggmeonina/scrumble/domain/squadmember/repository/impl/SquadMemberRepositoryImpl.java
@@ -34,4 +34,15 @@ public class SquadMemberRepositoryImpl implements SquadMemberRepositoryCustom {
 				)
 				.fetch();
 	}
+
+	@Override
+	public boolean existsBySquadMemberNotMemberId(Long squadId, Long memberId) {
+		Integer fetchOne = query.selectOne()
+			.from(squadMember)
+			.where(squadMember.member.id.ne(memberId)
+				.and(squadMember.squad.id.eq(squadId))
+				.and(squadMember.squadMemberStatus.eq(SquadMemberStatus.JOIN)))
+			.fetchFirst();
+		return fetchOne != null;
+	}
 }

--- a/src/main/java/com/eggmeonina/scrumble/domain/squadmember/service/SquadMemberService.java
+++ b/src/main/java/com/eggmeonina/scrumble/domain/squadmember/service/SquadMemberService.java
@@ -77,6 +77,17 @@ public class SquadMemberService {
 		foundMember.assignLeader();
 	}
 
+	@Transactional
+	public void leaveSquad(Long squadId, Long memberId){
+		SquadMember foundSquadMember = squadMemberRepository.findByMemberIdAndSquadId(memberId, squadId)
+			.orElseThrow(() -> new SquadMemberException(SQUADMEMBER_NOT_FOUND));
+		// 스쿼드에 인원이 있는 스쿼드 리더는 위임하거나 삭제만 가능하다.
+		if(foundSquadMember.isLeader() && squadMemberRepository.existsBySquadMemberNotMemberId(squadId, memberId)){
+			throw new SquadMemberException(LEADER_CANNOT_LEAVE);
+		}
+		foundSquadMember.leave();
+	}
+
 	private void hasAuthorization(SquadMember squadMember){
 		if(!squadMember.isLeader()){
 			throw new SquadMemberException(UNAUTHORIZED_ACTION);

--- a/src/test/java/com/eggmeonina/scrumble/domain/squadmember/domain/SquadMemberTest.java
+++ b/src/test/java/com/eggmeonina/scrumble/domain/squadmember/domain/SquadMemberTest.java
@@ -158,4 +158,26 @@ class SquadMemberTest {
 		assertThat(newMembership.isLeader()).isFalse();
 	}
 
+	@Test
+	@DisplayName("스쿼드를 탈퇴한다_성공")
+	void leave_success() {
+		// given
+		Member newMember = new Member("test@test.com", "test", "", new OauthInformation("1234", OauthType.GOOGLE),
+			MemberStatus.JOIN, LocalDateTime.now());
+		Squad newSquad = new Squad("test group", false);
+
+		SquadMember newSquadMember = SquadMember.create()
+			.member(newMember)
+			.squadMemberRole(SquadMemberRole.LEADER)
+			.squadMemberStatus(SquadMemberStatus.JOIN)
+			.squad(newSquad)
+			.build();
+
+		// when
+		newSquadMember.leave();
+
+		// then
+		assertThat(newSquadMember.getSquadMemberStatus()).isEqualTo(SquadMemberStatus.LEAVE);
+	}
+
 }

--- a/src/test/java/com/eggmeonina/scrumble/domain/squadmember/service/SquadMemberServiceAndSquadIntegrationTest.java
+++ b/src/test/java/com/eggmeonina/scrumble/domain/squadmember/service/SquadMemberServiceAndSquadIntegrationTest.java
@@ -269,7 +269,7 @@ class SquadMemberServiceAndSquadIntegrationTest extends IntegrationTestHelper {
 			.member(newMember1)
 			.squad(newSquad)
 			.squadMemberRole(SquadMemberRole.LEADER)
-			.squadMemberStatus(SquadMemberStatus.WITHDRAW)
+			.squadMemberStatus(SquadMemberStatus.LEAVE)
 			.build();
 
 		memberRepository.save(newMember1);
@@ -318,7 +318,7 @@ class SquadMemberServiceAndSquadIntegrationTest extends IntegrationTestHelper {
 			.member(newMember2)
 			.squad(newSquad)
 			.squadMemberRole(SquadMemberRole.NORMAL)
-			.squadMemberStatus(SquadMemberStatus.WITHDRAW)
+			.squadMemberStatus(SquadMemberStatus.LEAVE)
 			.build();
 
 		memberRepository.save(newMember1);
@@ -370,7 +370,7 @@ class SquadMemberServiceAndSquadIntegrationTest extends IntegrationTestHelper {
 			.member(newMember2)
 			.squad(newSquad)
 			.squadMemberRole(SquadMemberRole.NORMAL)
-			.squadMemberStatus(SquadMemberStatus.WITHDRAW)
+			.squadMemberStatus(SquadMemberStatus.LEAVE)
 			.build();
 
 		memberRepository.save(newMember1);
@@ -384,5 +384,148 @@ class SquadMemberServiceAndSquadIntegrationTest extends IntegrationTestHelper {
 
 		// then
 		assertThat(response.getSquadMembers()).hasSize(1);
+	}
+
+	@Test
+	@DisplayName("리더가 멤버가 없는 스쿼드를 탈퇴한다_성공")
+	void leaveSquadWhenMemberNotInSquad_success() {
+		// given
+		Member newMember = Member.create()
+			.name("testA")
+			.email("test@test.com")
+			.memberStatus(MemberStatus.JOIN)
+			.oauthInformation(new OauthInformation("123456789", OauthType.GOOGLE))
+			.joinedAt(LocalDateTime.now())
+			.build();
+
+		Squad newSquad = Squad.create()
+			.squadName("테스트 스쿼드")
+			.deletedFlag(false)
+			.build();
+
+		SquadMember newSquadMember = SquadMember.create()
+			.member(newMember)
+			.squad(newSquad)
+			.squadMemberRole(SquadMemberRole.LEADER)
+			.squadMemberStatus(SquadMemberStatus.JOIN)
+			.build();
+
+		memberRepository.save(newMember);
+		squadRepository.save(newSquad);
+		squadMemberRepository.save(newSquadMember);
+
+		// when
+		squadMemberService.leaveSquad(newSquad.getId(), newMember.getId());
+
+		SquadMember foundMember = squadMemberRepository.findById(newSquadMember.getId()).get();
+
+		// then
+		assertThat(foundMember.getSquadMemberStatus()).isEqualTo(SquadMemberStatus.LEAVE);
+	}
+
+	@Test
+	@DisplayName("리더가 탈퇴한 멤버만 있는 스쿼드를 탈퇴한다_성공")
+	void leaveSquadWhenLeavedMemberInSquad_success() {
+		// given
+		Member newMember1 = Member.create()
+			.name("testA")
+			.email("test@test.com")
+			.memberStatus(MemberStatus.JOIN)
+			.oauthInformation(new OauthInformation("123456789", OauthType.GOOGLE))
+			.joinedAt(LocalDateTime.now())
+			.build();
+
+		Member newMember2 = Member.create()
+			.name("testB")
+			.email("test2@test.com")
+			.memberStatus(MemberStatus.WITHDRAW)
+			.oauthInformation(new OauthInformation("987654321", OauthType.GOOGLE))
+			.joinedAt(LocalDateTime.now())
+			.build();
+
+		Squad newSquad = Squad.create()
+			.squadName("테스트 스쿼드")
+			.deletedFlag(false)
+			.build();
+
+		SquadMember newSquadMember1 = SquadMember.create()
+			.member(newMember1)
+			.squad(newSquad)
+			.squadMemberRole(SquadMemberRole.LEADER)
+			.squadMemberStatus(SquadMemberStatus.JOIN)
+			.build();
+
+		SquadMember newSquadMember2 = SquadMember.create()
+			.member(newMember2)
+			.squad(newSquad)
+			.squadMemberRole(SquadMemberRole.NORMAL)
+			.squadMemberStatus(SquadMemberStatus.LEAVE)
+			.build();
+
+		memberRepository.save(newMember1);
+		memberRepository.save(newMember2);
+		squadRepository.save(newSquad);
+		squadMemberRepository.save(newSquadMember1);
+		squadMemberRepository.save(newSquadMember2);
+
+		// when
+		squadMemberService.leaveSquad(newSquad.getId(), newMember1.getId());
+
+		SquadMember foundMember = squadMemberRepository.findById(newSquadMember1.getId()).get();
+
+		// then
+		assertThat(foundMember.getSquadMemberStatus()).isEqualTo(SquadMemberStatus.LEAVE);
+	}
+
+	@Test
+	@DisplayName("리더가 멤버가 있는 스쿼드를 탈퇴한다_실패")
+	void leaveSquadWhenMemberInSquad_fail() {
+		// given
+		Member newMember1 = Member.create()
+			.name("testA")
+			.email("test@test.com")
+			.memberStatus(MemberStatus.JOIN)
+			.oauthInformation(new OauthInformation("123456789", OauthType.GOOGLE))
+			.joinedAt(LocalDateTime.now())
+			.build();
+
+		Member newMember2 = Member.create()
+			.name("testB")
+			.email("test2@test.com")
+			.memberStatus(MemberStatus.WITHDRAW)
+			.oauthInformation(new OauthInformation("987654321", OauthType.GOOGLE))
+			.joinedAt(LocalDateTime.now())
+			.build();
+
+		Squad newSquad = Squad.create()
+			.squadName("테스트 스쿼드")
+			.deletedFlag(false)
+			.build();
+
+		SquadMember newSquadMember1 = SquadMember.create()
+			.member(newMember1)
+			.squad(newSquad)
+			.squadMemberRole(SquadMemberRole.LEADER)
+			.squadMemberStatus(SquadMemberStatus.JOIN)
+			.build();
+
+		SquadMember newSquadMember2 = SquadMember.create()
+			.member(newMember2)
+			.squad(newSquad)
+			.squadMemberRole(SquadMemberRole.NORMAL)
+			.squadMemberStatus(SquadMemberStatus.JOIN)
+			.build();
+
+		memberRepository.save(newMember1);
+		memberRepository.save(newMember2);
+		squadRepository.save(newSquad);
+		squadMemberRepository.save(newSquadMember1);
+		squadMemberRepository.save(newSquadMember2);
+
+		// when
+		assertThatThrownBy(() ->squadMemberService.leaveSquad(newSquad.getId(), newMember1.getId()))
+			.isInstanceOf(SquadMemberException.class)
+			.hasMessageContaining(LEADER_CANNOT_LEAVE.getMessage())
+			;
 	}
 }


### PR DESCRIPTION
## 관련 이슈
#41 

## 작업 사항
<!-- 가장 대표적인 작업 내용 -->
스쿼드 탈퇴 기능 개발

### 추가 정보
<!-- 이 PR에 대한 추가적인 정보가 필요하다면 작성해주세요. -->
- 일반 회원은 언제나 스쿼드를 탈퇴할 수 있다.
- 스쿼드를 탈퇴해도 투두리스트는 남는다.
- 리더가 탈퇴 요청 시
  - 스쿼드에 멤버가 있는 경우, 탈퇴가 불가능하다. -> 위임 혹은 스쿼드 삭제
  - 스쿼드에 멤버가 없는 경우, 탈퇴