### PR TITLE
Feat: 스쿼드 삭제 기능 개발

### DIFF
--- a/src/main/java/com/eggmeonina/scrumble/domain/squadmember/controller/SquadController.java
+++ b/src/main/java/com/eggmeonina/scrumble/domain/squadmember/controller/SquadController.java
@@ -117,4 +117,14 @@ public class SquadController {
 		squadMemberService.kickSquadMember(member.getMemberId(), squadId, memberId);
 		return ApiResponse.createSuccessWithNoContentResponse(HttpStatus.OK.value());
 	}
+
+	@DeleteMapping("/{squadId}")
+	@Operation(summary = "스쿼드를 삭제한다", description = "스쿼드를 삭제한다. 단, 리더인 경우에만 삭제가 가능하다. 삭제 시 모든 멤버는 탈퇴된다.")
+	public ApiResponse<Void> deleteSquad(
+		@Parameter(hidden = true) @Member LoginMember member,
+		@PathVariable("squadId") Long squadId
+	){
+		squadMemberService.deleteSquad(squadId, member.getMemberId());
+		return ApiResponse.createSuccessWithNoContentResponse(HttpStatus.OK.value());
+	}
 }

--- a/src/main/java/com/eggmeonina/scrumble/domain/squadmember/domain/Squad.java
+++ b/src/main/java/com/eggmeonina/scrumble/domain/squadmember/domain/Squad.java
@@ -43,4 +43,8 @@ public class Squad extends BaseEntity {
 	public void rename(String newSquadName){
 		this.squadName = newSquadName;
 	}
+
+	public void delete(){
+		this.deletedFlag = true;
+	}
 }

--- a/src/main/java/com/eggmeonina/scrumble/domain/squadmember/facade/SquadMemberFacadeService.java
+++ b/src/main/java/com/eggmeonina/scrumble/domain/squadmember/facade/SquadMemberFacadeService.java
@@ -21,7 +21,7 @@ public class SquadMemberFacadeService {
 		// 스쿼드를 생성한다.
 		Long squadId = squadService.createSquad(request);
 		// 스쿼드장을 등록한다.
-		squadMemberService.createMembership(memberId, squadId);
+		squadMemberService.createSquadMember(memberId, squadId);
 		return squadId;
 	}
 }

--- a/src/main/java/com/eggmeonina/scrumble/domain/squadmember/repository/SquadMemberRepository.java
+++ b/src/main/java/com/eggmeonina/scrumble/domain/squadmember/repository/SquadMemberRepository.java
@@ -1,5 +1,6 @@
 package com.eggmeonina.scrumble.domain.squadmember.repository;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -17,4 +18,11 @@ public interface SquadMemberRepository extends JpaRepository<SquadMember,Long>, 
        WHERE s.member.id = :memberId AND s.squad.id = :squadId AND s.squadMemberStatus = 'JOIN'
       """)
 	Optional<SquadMember> findByMemberIdAndSquadId(final Long memberId, final Long squadId);
+
+	@Query("""
+	 SELECT s
+	   FROM SquadMember s
+	  WHERE s.squad.id = :squadId AND s.squadMemberStatus = 'JOIN'
+	""")
+	List<SquadMember> findBySquadId(final Long squadId);
 }

--- a/src/main/java/com/eggmeonina/scrumble/domain/squadmember/service/SquadMemberService.java
+++ b/src/main/java/com/eggmeonina/scrumble/domain/squadmember/service/SquadMemberService.java
@@ -33,7 +33,7 @@ public class SquadMemberService {
 	private final SquadRepository squadRepository;
 
 	@Transactional
-	public Long createMembership(Long memberId, Long squadId){
+	public Long createSquadMember(Long memberId, Long squadId){
 		Member foundMember = memberRepository.findById(memberId)
 			.orElseThrow(() -> new MemberException(MEMBER_NOT_FOUND));
 
@@ -100,6 +100,21 @@ public class SquadMemberService {
 
 		// 멤버를 탈퇴시킨다.
 		squadMember.leave();
+	}
+
+	@Transactional
+	public void deleteSquad(Long squadId, Long leaderId){
+		Squad foundSquad = squadRepository.findById(squadId)
+			.orElseThrow(() -> new SquadException(SQUAD_NOT_FOUND));
+
+		// 리더가 권한을 가졌는지 확인한다.
+		SquadMember squadLeader = squadMemberRepository.findByMemberIdAndSquadId(leaderId, squadId)
+			.orElseThrow(() -> new SquadMemberException(SQUADMEMBER_NOT_FOUND));
+		hasAuthorization(squadLeader);
+
+		// 스쿼드 멤버들을 모두 탈퇴 시킨다.
+		squadMemberRepository.findBySquadId(squadId).forEach(SquadMember::leave);
+		foundSquad.delete();
 	}
 
 	private void hasAuthorization(SquadMember squadMember){

--- a/src/test/java/com/eggmeonina/scrumble/domain/squadmember/domain/SquadTest.java
+++ b/src/test/java/com/eggmeonina/scrumble/domain/squadmember/domain/SquadTest.java
@@ -25,4 +25,20 @@ class SquadTest {
 		assertThat(newSquad.getSquadName()).isEqualTo(newName);
 	}
 
+	@Test
+	@DisplayName("스쿼드를 삭제한다_성공")
+	void delete_success() {
+		// given
+		Squad newSquad = Squad.create()
+			.squadName("테스트 스쿼드")
+			.deletedFlag(false)
+			.build();
+
+		// when
+		newSquad.delete();
+
+		// then
+		assertThat(newSquad.isDeletedFlag()).isTrue();
+	}
+
 }

--- a/src/test/java/com/eggmeonina/scrumble/domain/squadmember/facade/SquadMemberFacadeServiceTest.java
+++ b/src/test/java/com/eggmeonina/scrumble/domain/squadmember/facade/SquadMemberFacadeServiceTest.java
@@ -37,7 +37,7 @@ class SquadMemberFacadeServiceTest {
 		SquadCreateRequest request = new SquadCreateRequest("테스트 스쿼드");
 
 		given(squadService.createSquad(any())).willReturn(squadId);
-		given(squadMemberService.createMembership(anyLong(), anyLong())).willReturn(membershipId);
+		given(squadMemberService.createSquadMember(anyLong(), anyLong())).willReturn(membershipId);
 
 		// when
 		Long newSquadId = squadMemberFacadeService.createSquad(memberId, request);

--- a/src/test/java/com/eggmeonina/scrumble/domain/squadmember/service/SquadMemberServiceAndSquadIntegrationTest.java
+++ b/src/test/java/com/eggmeonina/scrumble/domain/squadmember/service/SquadMemberServiceAndSquadIntegrationTest.java
@@ -1,10 +1,10 @@
 package com.eggmeonina.scrumble.domain.squadmember.service;
 
 import static com.eggmeonina.scrumble.common.exception.ErrorCode.*;
+import static com.eggmeonina.scrumble.fixture.SquadMemberFixture.*;
 import static org.assertj.core.api.Assertions.*;
 import static org.assertj.core.api.SoftAssertions.*;
 
-import java.time.LocalDateTime;
 import java.util.List;
 
 import org.junit.jupiter.api.DisplayName;
@@ -14,10 +14,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import com.eggmeonina.scrumble.common.exception.MemberException;
 import com.eggmeonina.scrumble.common.exception.SquadMemberException;
 import com.eggmeonina.scrumble.common.exception.SquadException;
-import com.eggmeonina.scrumble.domain.auth.domain.OauthType;
 import com.eggmeonina.scrumble.domain.member.domain.Member;
 import com.eggmeonina.scrumble.domain.member.domain.MemberStatus;
-import com.eggmeonina.scrumble.domain.member.domain.OauthInformation;
 import com.eggmeonina.scrumble.domain.member.repository.MemberRepository;
 import com.eggmeonina.scrumble.domain.squadmember.domain.SquadMember;
 import com.eggmeonina.scrumble.domain.squadmember.domain.SquadMemberRole;
@@ -50,25 +48,16 @@ class SquadMemberServiceAndSquadIntegrationTest extends IntegrationTestHelper {
 	@DisplayName("회원과 스쿼드로 멤버십을 생성한다")
 	void createMembership_success_returnsMembershipId() {
 		// given
-		Member newMember = Member.create()
-			.name("testA")
-			.email("test@test.com")
-			.memberStatus(MemberStatus.JOIN)
-			.oauthInformation(new OauthInformation("123456789", OauthType.GOOGLE))
-			.joinedAt(LocalDateTime.now())
-			.build();
+		Member newMember = createMember("testA", "test@test.com", MemberStatus.JOIN);
 
-		Squad newSquad = Squad.create()
-			.squadName("테스트 스쿼드")
-			.deletedFlag(false)
-			.build();
+		Squad newSquad = createSquad("테스트 스쿼드");
 
 		memberRepository.save(newMember);
 		squadRepository.save(newSquad);
 
 		// when
 		Long membershipId =
-			squadMemberService.createMembership(newMember.getId(), newSquad.getId());
+			squadMemberService.createSquadMember(newMember.getId(), newSquad.getId());
 
 		SquadMember foundSquadMember = squadMemberRepository.findById(membershipId).get();
 
@@ -80,25 +69,16 @@ class SquadMemberServiceAndSquadIntegrationTest extends IntegrationTestHelper {
 	@DisplayName("회원 없이 스쿼드만으로 멤버십을 생성하면 예외가 발생한다")
 	void createMembershipWithoutMember_fail_throwsException() {
 		// given
-		Member newMember = Member.create()
-			.name("testA")
-			.email("test@test.com")
-			.memberStatus(MemberStatus.JOIN)
-			.oauthInformation(new OauthInformation("123456789", OauthType.GOOGLE))
-			.joinedAt(LocalDateTime.now())
-			.build();
+		Member newMember = createMember("testA", "test@test.com", MemberStatus.JOIN);
 
-		Squad newSquad = Squad.create()
-			.squadName("테스트 스쿼드")
-			.deletedFlag(false)
-			.build();
+		Squad newSquad = createSquad("테스트 스쿼드");
 
 		memberRepository.save(newMember);
 		squadRepository.save(newSquad);
 
 		// when
 		Long squadId = newSquad.getId();
-		assertThatThrownBy(() -> squadMemberService.createMembership(0L, squadId))
+		assertThatThrownBy(() -> squadMemberService.createSquadMember(0L, squadId))
 			.isInstanceOf(MemberException.class)
 			.hasMessageContaining(MEMBER_NOT_FOUND.getMessage());
 	}
@@ -107,25 +87,16 @@ class SquadMemberServiceAndSquadIntegrationTest extends IntegrationTestHelper {
 	@DisplayName("스쿼드 없이 회원만으로 멤버십을 생성하면 예외가 발생한다")
 	void createMembershipWithoutSquad_fail_throwsException() {
 		// given
-		Member newMember = Member.create()
-			.name("testA")
-			.email("test@test.com")
-			.memberStatus(MemberStatus.JOIN)
-			.oauthInformation(new OauthInformation("123456789", OauthType.GOOGLE))
-			.joinedAt(LocalDateTime.now())
-			.build();
+		Member newMember = createMember("testA", "test@test.com", MemberStatus.JOIN);
 
-		Squad newSquad = Squad.create()
-			.squadName("테스트 스쿼드")
-			.deletedFlag(false)
-			.build();
+		Squad newSquad = createSquad("테스트 스쿼드");
 
 		memberRepository.save(newMember);
 		squadRepository.save(newSquad);
 
 		// when
 		Long memberId = newMember.getId();
-		assertThatThrownBy(() -> squadMemberService.createMembership(memberId, 0L))
+		assertThatThrownBy(() -> squadMemberService.createSquadMember(memberId, 0L))
 			.isInstanceOf(SquadMemberException.class)
 			.hasMessageContaining(SQUAD_NOT_FOUND.getMessage());
 	}
@@ -134,25 +105,12 @@ class SquadMemberServiceAndSquadIntegrationTest extends IntegrationTestHelper {
 	@DisplayName("나의 스쿼드들을 조회한다")
 	void findSquads_success_returnSquads() {
 		// given
-		Member newMember = Member.create()
-			.name("testA")
-			.email("test@test.com")
-			.memberStatus(MemberStatus.JOIN)
-			.oauthInformation(new OauthInformation("123456789", OauthType.GOOGLE))
-			.joinedAt(LocalDateTime.now())
-			.build();
+		Member newMember = createMember("testA", "test@test.com", MemberStatus.JOIN);
 
-		Squad newSquad = Squad.create()
-			.squadName("테스트 스쿼드")
-			.deletedFlag(false)
-			.build();
+		Squad newSquad = createSquad("테스트 스쿼드");
 
-		SquadMember newSquadMember = SquadMember.create()
-			.member(newMember)
-			.squad(newSquad)
-			.squadMemberRole(SquadMemberRole.LEADER)
-			.squadMemberStatus(SquadMemberStatus.JOIN)
-			.build();
+		SquadMember newSquadMember = createSquadMember(newSquad, newMember, SquadMemberRole.LEADER,
+			SquadMemberStatus.JOIN);
 
 		memberRepository.save(newMember);
 		squadRepository.save(newSquad);
@@ -173,13 +131,7 @@ class SquadMemberServiceAndSquadIntegrationTest extends IntegrationTestHelper {
 	@DisplayName("나의 스쿼드들을 조회한다_0개")
 	void findBySquads_empty_returnEmptyList() {
 		// given
-		Member newMember = Member.create()
-			.name("testA")
-			.email("test@test.com")
-			.memberStatus(MemberStatus.JOIN)
-			.oauthInformation(new OauthInformation("123456789", OauthType.GOOGLE))
-			.joinedAt(LocalDateTime.now())
-			.build();
+		Member newMember = createMember("testA", "test@test.com", MemberStatus.JOIN);
 
 		memberRepository.save(newMember);
 
@@ -194,40 +146,17 @@ class SquadMemberServiceAndSquadIntegrationTest extends IntegrationTestHelper {
 	@DisplayName("스쿼드를 조회한다_성공")
 	void findSquadAndMembers_success_returnSquadDetailResponse() {
 		// given
-		Member newMember1 = Member.create()
-			.name("testA")
-			.email("test@test.com")
-			.memberStatus(MemberStatus.JOIN)
-			.oauthInformation(new OauthInformation("123456789", OauthType.GOOGLE))
-			.joinedAt(LocalDateTime.now())
-			.build();
+		Member newMember1 = createMember("testA", "test@test.com", MemberStatus.JOIN);
 
-		Member newMember2 = Member.create()
-			.name("testB")
-			.email("test2@test.com")
-			.memberStatus(MemberStatus.JOIN)
-			.oauthInformation(new OauthInformation("987654321", OauthType.GOOGLE))
-			.joinedAt(LocalDateTime.now())
-			.build();
+		Member newMember2 = createMember("testB", "test2@test.com", MemberStatus.JOIN);
 
-		Squad newSquad = Squad.create()
-			.squadName("테스트 스쿼드")
-			.deletedFlag(false)
-			.build();
+		Squad newSquad = createSquad("테스트 스쿼드");
 
-		SquadMember newSquadMember1 = SquadMember.create()
-			.member(newMember1)
-			.squad(newSquad)
-			.squadMemberRole(SquadMemberRole.LEADER)
-			.squadMemberStatus(SquadMemberStatus.JOIN)
-			.build();
+		SquadMember newSquadMember1 = createSquadMember(newSquad, newMember1, SquadMemberRole.LEADER,
+			SquadMemberStatus.JOIN);
 
-		SquadMember newSquadMember2 = SquadMember.create()
-			.member(newMember2)
-			.squad(newSquad)
-			.squadMemberRole(SquadMemberRole.NORMAL)
-			.squadMemberStatus(SquadMemberStatus.JOIN)
-			.build();
+		SquadMember newSquadMember2 = createSquadMember(newSquad, newMember2, SquadMemberRole.NORMAL,
+			SquadMemberStatus.JOIN);
 
 		memberRepository.save(newMember1);
 		memberRepository.save(newMember2);
@@ -244,40 +173,32 @@ class SquadMemberServiceAndSquadIntegrationTest extends IntegrationTestHelper {
 			softly.assertThat(response.getSquadName()).isEqualTo(newSquad.getSquadName());
 			softly.assertThat(response.getSquadMembers().get(0).getMemberId()).isEqualTo(newMember1.getId());
 			softly.assertThat(response.getSquadMembers().get(0).getName()).isEqualTo(newMember1.getName());
-			softly.assertThat(response.getSquadMembers().get(0).getProfileImg()).isEqualTo(newMember1.getProfileImage());
+			softly.assertThat(response.getSquadMembers().get(0).getProfileImg())
+				.isEqualTo(newMember1.getProfileImage());
 			softly.assertThat(response.getSquadMembers()).hasSize(2);
 		});
 	}
+
 	@Test
 	@DisplayName("삭제된 스쿼드를 조회한다_실패")
 	void findSquadAndMembers_fail_throwsSquadException() {
 		// given
-		Member newMember1 = Member.create()
-			.name("testA")
-			.email("test@test.com")
-			.memberStatus(MemberStatus.JOIN)
-			.oauthInformation(new OauthInformation("123456789", OauthType.GOOGLE))
-			.joinedAt(LocalDateTime.now())
-			.build();
+		Member newMember1 = createMember("testA", "test@test.com", MemberStatus.JOIN);
 
 		Squad newSquad = Squad.create()
 			.squadName("테스트 스쿼드")
 			.deletedFlag(true)
 			.build();
 
-		SquadMember newSquadMember1 = SquadMember.create()
-			.member(newMember1)
-			.squad(newSquad)
-			.squadMemberRole(SquadMemberRole.LEADER)
-			.squadMemberStatus(SquadMemberStatus.LEAVE)
-			.build();
+		SquadMember newSquadMember1 = createSquadMember(newSquad, newMember1, SquadMemberRole.LEADER,
+			SquadMemberStatus.LEAVE);
 
 		memberRepository.save(newMember1);
 		squadRepository.save(newSquad);
 		squadMemberRepository.save(newSquadMember1);
 
 		// when
-		assertThatThrownBy(()->squadService.findSquadAndMembers(newSquad.getId()))
+		assertThatThrownBy(() -> squadService.findSquadAndMembers(newSquad.getId()))
 			.isInstanceOf(SquadException.class)
 			.hasMessageContaining(SQUAD_NOT_FOUND.getMessage());
 	}
@@ -286,40 +207,17 @@ class SquadMemberServiceAndSquadIntegrationTest extends IntegrationTestHelper {
 	@DisplayName("스쿼드를 탈퇴한 멤버가 있는 스쿼드를 조회한다_성공")
 	void findSquadAndMembersWithWithdrawMemberFromSquad_success_returnSquadDetailResponse() {
 		// given
-		Member newMember1 = Member.create()
-			.name("testA")
-			.email("test@test.com")
-			.memberStatus(MemberStatus.JOIN)
-			.oauthInformation(new OauthInformation("123456789", OauthType.GOOGLE))
-			.joinedAt(LocalDateTime.now())
-			.build();
+		Member newMember1 = createMember("testA", "test@test.com", MemberStatus.JOIN);
 
-		Member newMember2 = Member.create()
-			.name("testB")
-			.email("test2@test.com")
-			.memberStatus(MemberStatus.JOIN)
-			.oauthInformation(new OauthInformation("987654321", OauthType.GOOGLE))
-			.joinedAt(LocalDateTime.now())
-			.build();
+		Member newMember2 = createMember("testB", "test2@test.com", MemberStatus.JOIN);
 
-		Squad newSquad = Squad.create()
-			.squadName("테스트 스쿼드")
-			.deletedFlag(false)
-			.build();
+		Squad newSquad = createSquad("테스트 스쿼드");
 
-		SquadMember newSquadMember1 = SquadMember.create()
-			.member(newMember1)
-			.squad(newSquad)
-			.squadMemberRole(SquadMemberRole.LEADER)
-			.squadMemberStatus(SquadMemberStatus.JOIN)
-			.build();
+		SquadMember newSquadMember1 = createSquadMember(newSquad, newMember1, SquadMemberRole.LEADER,
+			SquadMemberStatus.JOIN);
 
-		SquadMember newSquadMember2 = SquadMember.create()
-			.member(newMember2)
-			.squad(newSquad)
-			.squadMemberRole(SquadMemberRole.NORMAL)
-			.squadMemberStatus(SquadMemberStatus.LEAVE)
-			.build();
+		SquadMember newSquadMember2 = createSquadMember(newSquad, newMember2, SquadMemberRole.NORMAL,
+			SquadMemberStatus.LEAVE);
 
 		memberRepository.save(newMember1);
 		memberRepository.save(newMember2);
@@ -338,40 +236,17 @@ class SquadMemberServiceAndSquadIntegrationTest extends IntegrationTestHelper {
 	@DisplayName("회원 탈퇴한 멤버가 있는 스쿼드를 조회한다_성공")
 	void findSquadWithWithdrawnMember_success_returnSquadDetailResponse() {
 		// given
-		Member newMember1 = Member.create()
-			.name("testA")
-			.email("test@test.com")
-			.memberStatus(MemberStatus.JOIN)
-			.oauthInformation(new OauthInformation("123456789", OauthType.GOOGLE))
-			.joinedAt(LocalDateTime.now())
-			.build();
+		Member newMember1 = createMember("testA", "test@test.com", MemberStatus.JOIN);
 
-		Member newMember2 = Member.create()
-			.name("testB")
-			.email("test2@test.com")
-			.memberStatus(MemberStatus.WITHDRAW)
-			.oauthInformation(new OauthInformation("987654321", OauthType.GOOGLE))
-			.joinedAt(LocalDateTime.now())
-			.build();
+		Member newMember2 = createMember("testB", "test2@test.com", MemberStatus.WITHDRAW);
 
-		Squad newSquad = Squad.create()
-			.squadName("테스트 스쿼드")
-			.deletedFlag(false)
-			.build();
+		Squad newSquad = createSquad("테스트 스쿼드");
 
-		SquadMember newSquadMember1 = SquadMember.create()
-			.member(newMember1)
-			.squad(newSquad)
-			.squadMemberRole(SquadMemberRole.LEADER)
-			.squadMemberStatus(SquadMemberStatus.JOIN)
-			.build();
+		SquadMember newSquadMember1 = createSquadMember(newSquad, newMember1, SquadMemberRole.LEADER,
+			SquadMemberStatus.JOIN);
 
-		SquadMember newSquadMember2 = SquadMember.create()
-			.member(newMember2)
-			.squad(newSquad)
-			.squadMemberRole(SquadMemberRole.NORMAL)
-			.squadMemberStatus(SquadMemberStatus.LEAVE)
-			.build();
+		SquadMember newSquadMember2 = createSquadMember(newSquad, newMember2, SquadMemberRole.NORMAL,
+			SquadMemberStatus.LEAVE);
 
 		memberRepository.save(newMember1);
 		memberRepository.save(newMember2);
@@ -390,25 +265,12 @@ class SquadMemberServiceAndSquadIntegrationTest extends IntegrationTestHelper {
 	@DisplayName("리더가 멤버가 없는 스쿼드를 탈퇴한다_성공")
 	void leaveSquadWhenMemberNotInSquad_success() {
 		// given
-		Member newMember = Member.create()
-			.name("testA")
-			.email("test@test.com")
-			.memberStatus(MemberStatus.JOIN)
-			.oauthInformation(new OauthInformation("123456789", OauthType.GOOGLE))
-			.joinedAt(LocalDateTime.now())
-			.build();
+		Member newMember = createMember("testA", "test@test.com", MemberStatus.JOIN);
 
-		Squad newSquad = Squad.create()
-			.squadName("테스트 스쿼드")
-			.deletedFlag(false)
-			.build();
+		Squad newSquad = createSquad("테스트 스쿼드");
 
-		SquadMember newSquadMember = SquadMember.create()
-			.member(newMember)
-			.squad(newSquad)
-			.squadMemberRole(SquadMemberRole.LEADER)
-			.squadMemberStatus(SquadMemberStatus.JOIN)
-			.build();
+		SquadMember newSquadMember = createSquadMember(newSquad, newMember, SquadMemberRole.LEADER,
+			SquadMemberStatus.JOIN);
 
 		memberRepository.save(newMember);
 		squadRepository.save(newSquad);
@@ -427,40 +289,17 @@ class SquadMemberServiceAndSquadIntegrationTest extends IntegrationTestHelper {
 	@DisplayName("리더가 탈퇴한 멤버만 있는 스쿼드를 탈퇴한다_성공")
 	void leaveSquadWhenLeavedMemberInSquad_success() {
 		// given
-		Member newMember1 = Member.create()
-			.name("testA")
-			.email("test@test.com")
-			.memberStatus(MemberStatus.JOIN)
-			.oauthInformation(new OauthInformation("123456789", OauthType.GOOGLE))
-			.joinedAt(LocalDateTime.now())
-			.build();
+		Member newMember1 = createMember("testA", "test@test.com", MemberStatus.JOIN);
 
-		Member newMember2 = Member.create()
-			.name("testB")
-			.email("test2@test.com")
-			.memberStatus(MemberStatus.WITHDRAW)
-			.oauthInformation(new OauthInformation("987654321", OauthType.GOOGLE))
-			.joinedAt(LocalDateTime.now())
-			.build();
+		Member newMember2 = createMember("testB", "test2@test.com", MemberStatus.WITHDRAW);
 
-		Squad newSquad = Squad.create()
-			.squadName("테스트 스쿼드")
-			.deletedFlag(false)
-			.build();
+		Squad newSquad = createSquad("테스트 스쿼드");
 
-		SquadMember newSquadMember1 = SquadMember.create()
-			.member(newMember1)
-			.squad(newSquad)
-			.squadMemberRole(SquadMemberRole.LEADER)
-			.squadMemberStatus(SquadMemberStatus.JOIN)
-			.build();
+		SquadMember newSquadMember1 = createSquadMember(newSquad, newMember1, SquadMemberRole.LEADER,
+			SquadMemberStatus.JOIN);
 
-		SquadMember newSquadMember2 = SquadMember.create()
-			.member(newMember2)
-			.squad(newSquad)
-			.squadMemberRole(SquadMemberRole.NORMAL)
-			.squadMemberStatus(SquadMemberStatus.LEAVE)
-			.build();
+		SquadMember newSquadMember2 = createSquadMember(newSquad, newMember2, SquadMemberRole.NORMAL,
+			SquadMemberStatus.LEAVE);
 
 		memberRepository.save(newMember1);
 		memberRepository.save(newMember2);
@@ -481,40 +320,17 @@ class SquadMemberServiceAndSquadIntegrationTest extends IntegrationTestHelper {
 	@DisplayName("리더가 멤버가 있는 스쿼드를 탈퇴한다_실패")
 	void leaveSquadWhenMemberInSquad_fail() {
 		// given
-		Member newMember1 = Member.create()
-			.name("testA")
-			.email("test@test.com")
-			.memberStatus(MemberStatus.JOIN)
-			.oauthInformation(new OauthInformation("123456789", OauthType.GOOGLE))
-			.joinedAt(LocalDateTime.now())
-			.build();
+		Member newMember1 = createMember("testA", "test@test.com", MemberStatus.JOIN);
 
-		Member newMember2 = Member.create()
-			.name("testB")
-			.email("test2@test.com")
-			.memberStatus(MemberStatus.WITHDRAW)
-			.oauthInformation(new OauthInformation("987654321", OauthType.GOOGLE))
-			.joinedAt(LocalDateTime.now())
-			.build();
+		Member newMember2 = createMember("testB", "test2@test.com", MemberStatus.WITHDRAW);
 
-		Squad newSquad = Squad.create()
-			.squadName("테스트 스쿼드")
-			.deletedFlag(false)
-			.build();
+		Squad newSquad = createSquad("테스트 스쿼드");
 
-		SquadMember newSquadMember1 = SquadMember.create()
-			.member(newMember1)
-			.squad(newSquad)
-			.squadMemberRole(SquadMemberRole.LEADER)
-			.squadMemberStatus(SquadMemberStatus.JOIN)
-			.build();
+		SquadMember newSquadMember1 = createSquadMember(newSquad, newMember1, SquadMemberRole.LEADER,
+			SquadMemberStatus.JOIN);
 
-		SquadMember newSquadMember2 = SquadMember.create()
-			.member(newMember2)
-			.squad(newSquad)
-			.squadMemberRole(SquadMemberRole.NORMAL)
-			.squadMemberStatus(SquadMemberStatus.JOIN)
-			.build();
+		SquadMember newSquadMember2 = createSquadMember(newSquad, newMember2, SquadMemberRole.NORMAL,
+			SquadMemberStatus.JOIN);
 
 		memberRepository.save(newMember1);
 		memberRepository.save(newMember2);
@@ -523,9 +339,79 @@ class SquadMemberServiceAndSquadIntegrationTest extends IntegrationTestHelper {
 		squadMemberRepository.save(newSquadMember2);
 
 		// when
-		assertThatThrownBy(() ->squadMemberService.leaveSquad(newSquad.getId(), newMember1.getId()))
+		assertThatThrownBy(() -> squadMemberService.leaveSquad(newSquad.getId(), newMember1.getId()))
 			.isInstanceOf(SquadMemberException.class)
 			.hasMessageContaining(LEADER_CANNOT_LEAVE.getMessage())
-			;
+		;
+	}
+
+	@Test
+	@DisplayName("스쿼드를 삭제한다_성공_1개")
+	void deleteSquadWithOneMember_success() {
+		// given
+		Member newMember = createMember("testA", "test@test.com", MemberStatus.JOIN);
+
+		Squad newSquad = createSquad("테스트 스쿼드");
+
+		SquadMember squadLeader =
+			createSquadMember(newSquad, newMember, SquadMemberRole.LEADER, SquadMemberStatus.JOIN);
+
+		memberRepository.save(newMember);
+		squadRepository.save(newSquad);
+		squadMemberRepository.save(squadLeader);
+
+		// when
+		squadMemberService.deleteSquad(newSquad.getId(), newMember.getId());
+
+		SquadMember foundLeader = squadMemberRepository.findById(squadLeader.getId()).get();
+		Squad foundSquad = squadRepository.findById(newSquad.getId()).get();
+
+		// then
+		assertSoftly(softly -> {
+			softly.assertThat(foundLeader.getSquadMemberStatus()).isEqualTo(SquadMemberStatus.LEAVE);
+			softly.assertThat(foundSquad.isDeletedFlag()).isTrue();
+		});
+	}
+
+	@Test
+	@DisplayName("스쿼드를 삭제한다_성공_N개")
+	void deleteSquadWithMembers_success() {
+		// given
+		Member newMember1 = createMember("testA", "test@test.com", MemberStatus.JOIN);
+		Member newMember2 = createMember("testB", "test2@test.com", MemberStatus.JOIN);
+		Member newMember3 = createMember("testC", "test3@test.com", MemberStatus.JOIN);
+
+		Squad newSquad = createSquad("테스트 스쿼드");
+
+		SquadMember squadLeader = createSquadMember(newSquad, newMember1, SquadMemberRole.LEADER,
+			SquadMemberStatus.JOIN);
+		SquadMember squadMember1 = createSquadMember(newSquad, newMember2, SquadMemberRole.NORMAL,
+			SquadMemberStatus.JOIN);
+		SquadMember squadMember2 = createSquadMember(newSquad, newMember3, SquadMemberRole.NORMAL,
+			SquadMemberStatus.JOIN);
+
+		memberRepository.save(newMember1);
+		memberRepository.save(newMember2);
+		memberRepository.save(newMember3);
+		squadRepository.save(newSquad);
+		squadMemberRepository.save(squadLeader);
+		squadMemberRepository.save(squadMember1);
+		squadMemberRepository.save(squadMember2);
+
+		// when
+		squadMemberService.deleteSquad(newSquad.getId(), newMember1.getId());
+
+		SquadMember foundLeader = squadMemberRepository.findById(squadLeader.getId()).get();
+		SquadMember foundMember1 = squadMemberRepository.findById(squadMember1.getId()).get();
+		SquadMember foundMember2 = squadMemberRepository.findById(squadMember2.getId()).get();
+		Squad foundSquad = squadRepository.findById(newSquad.getId()).get();
+
+		// then
+		assertSoftly(softly -> {
+			softly.assertThat(foundLeader.getSquadMemberStatus()).isEqualTo(SquadMemberStatus.LEAVE);
+			softly.assertThat(foundMember1.getSquadMemberStatus()).isEqualTo(SquadMemberStatus.LEAVE);
+			softly.assertThat(foundMember2.getSquadMemberStatus()).isEqualTo(SquadMemberStatus.LEAVE);
+			softly.assertThat(foundSquad.isDeletedFlag()).isTrue();
+		});
 	}
 }

--- a/src/test/java/com/eggmeonina/scrumble/fixture/SquadMemberFixture.java
+++ b/src/test/java/com/eggmeonina/scrumble/fixture/SquadMemberFixture.java
@@ -1,6 +1,7 @@
 package com.eggmeonina.scrumble.fixture;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 import com.eggmeonina.scrumble.domain.auth.domain.OauthType;
 import com.eggmeonina.scrumble.domain.member.domain.Member;
@@ -12,11 +13,11 @@ import com.eggmeonina.scrumble.domain.squadmember.domain.SquadMemberRole;
 import com.eggmeonina.scrumble.domain.squadmember.domain.SquadMemberStatus;
 
 public class SquadMemberFixture {
-	public static SquadMember createSquadMember(Squad newSquad, Member newLeader, SquadMemberRole leader, SquadMemberStatus status) {
+	public static SquadMember createSquadMember(Squad newSquad, Member member, SquadMemberRole role, SquadMemberStatus status) {
 		return SquadMember.create()
 			.squad(newSquad)
-			.member(newLeader)
-			.squadMemberRole(leader)
+			.member(member)
+			.squadMemberRole(role)
 			.squadMemberStatus(status)
 			.build();
 	}
@@ -36,5 +37,9 @@ public class SquadMemberFixture {
 			.oauthInformation(new OauthInformation("1234567", OauthType.GOOGLE))
 			.joinedAt(LocalDateTime.now())
 			.build();
+	}
+
+	public static List<SquadMember> createSquadMembers(SquadMember... squadMember){
+		return List.of(squadMember);
 	}
 }


### PR DESCRIPTION
## 관련 이슈
#33 

## 작업 사항
<!-- 가장 대표적인 작업 내용 -->
스쿼드 삭제 기능을 추가하였습니다.

### 추가 정보
<!-- 이 PR에 대한 추가적인 정보가 필요하다면 작성해주세요. -->
- 스쿼드 리더만 스쿼드를 삭제할 수 있다.
- 스쿼드원들은 모두 스쿼드에서 탈퇴된다.
- 스쿼드원들의 todo는 지워지지 않는다.
