### PR TITLE
Feat: Todo 삭제 기능 개발

### DIFF
--- a/src/main/java/com/eggmeonina/scrumble/common/exception/ErrorCode.java
+++ b/src/main/java/com/eggmeonina/scrumble/common/exception/ErrorCode.java
@@ -39,7 +39,9 @@ public enum ErrorCode {
 	/**
 	 * 투두
 	 */
-	TODO_NOT_FOUND(HttpStatus.BAD_REQUEST, "투두가 존재하지 않습니다.");
+	TODO_NOT_FOUND(HttpStatus.BAD_REQUEST, "투두가 존재하지 않습니다."),
+	SQUAD_TODO_NOT_FOUND(HttpStatus.BAD_REQUEST, "스쿼드에 속한 투두가 존재하지 않습니다."),
+	WRITER_IS_NOT_MATCH(HttpStatus.FORBIDDEN, "투두 작성자가 아닙니다.");
 
 	private final HttpStatus status;
 	private final String message;

--- a/src/main/java/com/eggmeonina/scrumble/common/exception/SquadToDoException.java
+++ b/src/main/java/com/eggmeonina/scrumble/common/exception/SquadToDoException.java
@@ -1,0 +1,7 @@
+package com.eggmeonina.scrumble.common.exception;
+
+public class SquadToDoException extends ExpectedException{
+	public SquadToDoException(ErrorCode errorCode) {
+		super(errorCode);
+	}
+}

--- a/src/main/java/com/eggmeonina/scrumble/domain/todo/controller/TodoController.java
+++ b/src/main/java/com/eggmeonina/scrumble/domain/todo/controller/TodoController.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -54,6 +55,17 @@ public class TodoController {
 	){
 		Long toDoId = squadToDoFacadeService.createToDoAndSquadToDo(squadId, member.getMemberId(), request);
 		return ApiResponse.createSuccessResponse(HttpStatus.OK.value(), Map.of("toDoId", toDoId));
+	}
+
+	@DeleteMapping("{toDoId}/squads/{squadId}")
+	@Operation(summary = "스쿼드에 속한 투두를 삭제한다", description = "본인의 스쿼드에 속한 투두를 삭제한다.")
+	public ApiResponse<Void> deleteToDo(
+		@Parameter(description = "투두 ID") @PathVariable Long toDoId,
+		@Parameter(description = "스쿼드 ID") @PathVariable Long squadId,
+		@Parameter(hidden = true) @Member LoginMember member
+	){
+		squadToDoFacadeService.deleteToDoAndSquadToDo(squadId, toDoId, member.getMemberId());
+		return ApiResponse.createSuccessWithNoContentResponse(HttpStatus.OK.value());
 	}
 
 }

--- a/src/main/java/com/eggmeonina/scrumble/domain/todo/domain/SquadToDo.java
+++ b/src/main/java/com/eggmeonina/scrumble/domain/todo/domain/SquadToDo.java
@@ -1,6 +1,8 @@
 package com.eggmeonina.scrumble.domain.todo.domain;
 
 import com.eggmeonina.scrumble.common.domain.BaseEntity;
+import com.eggmeonina.scrumble.common.exception.ErrorCode;
+import com.eggmeonina.scrumble.common.exception.SquadToDoException;
 import com.eggmeonina.scrumble.domain.squadmember.domain.Squad;
 
 import jakarta.persistence.Column;
@@ -40,8 +42,18 @@ public class SquadToDo extends BaseEntity {
 
 	@Builder(builderMethodName = "create")
 	public SquadToDo(ToDo toDo, Squad squad, boolean deletedFlag) {
+		if(toDo == null){
+			throw new SquadToDoException(ErrorCode.TODO_NOT_FOUND);
+		}
+		if(squad == null){
+			throw new SquadToDoException(ErrorCode.SQUAD_NOT_FOUND);
+		}
 		this.toDo = toDo;
 		this.squad = squad;
 		this.deletedFlag = deletedFlag;
+	}
+
+	public void delete(){
+		deletedFlag = true;
 	}
 }

--- a/src/main/java/com/eggmeonina/scrumble/domain/todo/domain/ToDo.java
+++ b/src/main/java/com/eggmeonina/scrumble/domain/todo/domain/ToDo.java
@@ -63,4 +63,8 @@ public class ToDo extends BaseEntity {
 		this.deletedFlag = deletedFlag;
 		this.member = member;
 	}
+
+	public void delete(){
+		this.deletedFlag = true;
+	}
 }

--- a/src/main/java/com/eggmeonina/scrumble/domain/todo/facade/SquadToDoFacadeService.java
+++ b/src/main/java/com/eggmeonina/scrumble/domain/todo/facade/SquadToDoFacadeService.java
@@ -1,8 +1,11 @@
 package com.eggmeonina.scrumble.domain.todo.facade;
 
+import static com.eggmeonina.scrumble.common.exception.ErrorCode.*;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.eggmeonina.scrumble.common.exception.ToDoException;
 import com.eggmeonina.scrumble.domain.todo.dto.SquadTodoCreateRequest;
 import com.eggmeonina.scrumble.domain.todo.service.SquadTodoService;
 import com.eggmeonina.scrumble.domain.todo.service.ToDoService;
@@ -28,5 +31,18 @@ public class SquadToDoFacadeService {
 		Long toDoId = toDoService.createToDo(memberId, request);
 		squadTodoService.createSquadToDo(squadId, toDoId);
 		return toDoId;
+	}
+
+	@Transactional
+	public void deleteToDoAndSquadToDo(Long squadId, Long toDoId, Long memberId){
+		// 투두 작성자를 확인한다.
+		if(!toDoService.isWriter(memberId, toDoId)){
+			throw new ToDoException(WRITER_IS_NOT_MATCH);
+		}
+
+		// 스쿼드 투두를 삭제한다.
+		squadTodoService.deleteSquadToDo(squadId, toDoId);
+		// 자신의 투두를 삭제한다.
+		toDoService.deleteToDo(toDoId);
 	}
 }

--- a/src/main/java/com/eggmeonina/scrumble/domain/todo/repository/SquadTodoRepository.java
+++ b/src/main/java/com/eggmeonina/scrumble/domain/todo/repository/SquadTodoRepository.java
@@ -1,10 +1,20 @@
 package com.eggmeonina.scrumble.domain.todo.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import com.eggmeonina.scrumble.domain.todo.domain.SquadToDo;
 
 @Repository
 public interface SquadTodoRepository extends JpaRepository<SquadToDo, Long>, SquadTodoRepositoryCustom {
+
+	@Query("""
+		SELECT sq
+		  FROM SquadToDo sq
+		 WHERE sq.toDo.id = :toDoId AND sq.squad.id = :squadId AND sq.deletedFlag = false
+		""")
+	Optional<SquadToDo> findByToDoIdAndSquadIdAndDeletedFlagNot(Long toDoId, Long squadId);
 }

--- a/src/main/java/com/eggmeonina/scrumble/domain/todo/repository/TodoRepository.java
+++ b/src/main/java/com/eggmeonina/scrumble/domain/todo/repository/TodoRepository.java
@@ -15,4 +15,6 @@ public interface TodoRepository extends JpaRepository<ToDo, Long> {
 		 WHERE t.id = :toDoId AND t.deletedFlag = false
 		""")
 	Optional<ToDo> findByIdAndDeletedFlagNot(Long toDoId);
+
+	boolean existsByIdAndMemberId(final Long toDoId, final Long memberId);
 }

--- a/src/main/java/com/eggmeonina/scrumble/domain/todo/service/SquadTodoService.java
+++ b/src/main/java/com/eggmeonina/scrumble/domain/todo/service/SquadTodoService.java
@@ -1,11 +1,12 @@
 package com.eggmeonina.scrumble.domain.todo.service;
 
+import static com.eggmeonina.scrumble.common.exception.ErrorCode.*;
+
 import java.util.List;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.eggmeonina.scrumble.common.exception.ErrorCode;
 import com.eggmeonina.scrumble.common.exception.SquadException;
 import com.eggmeonina.scrumble.common.exception.ToDoException;
 import com.eggmeonina.scrumble.domain.squadmember.domain.Squad;
@@ -35,9 +36,9 @@ public class SquadTodoService {
 	@Transactional
 	public Long createSquadToDo(Long squadId, Long toDoId) {
 		Squad foundSquad = squadRepository.findByIdAndDeletedFlagNot(squadId)
-			.orElseThrow(() -> new SquadException(ErrorCode.SQUAD_NOT_FOUND));
+			.orElseThrow(() -> new SquadException(SQUAD_NOT_FOUND));
 		ToDo foundTodo = todoRepository.findByIdAndDeletedFlagNot(toDoId)
-			.orElseThrow(() -> new ToDoException(ErrorCode.TODO_NOT_FOUND));
+			.orElseThrow(() -> new ToDoException(TODO_NOT_FOUND));
 
 		SquadToDo newSquadToDo = SquadToDo.create()
 			.squad(foundSquad)
@@ -47,6 +48,13 @@ public class SquadTodoService {
 
 		squadTodoRepository.save(newSquadToDo);
 		return newSquadToDo.getId();
+	}
+
+	@Transactional
+	public void deleteSquadToDo(Long squadId, Long toDoId){
+		SquadToDo foundSquadToDo = squadTodoRepository.findByToDoIdAndSquadIdAndDeletedFlagNot(toDoId, squadId)
+			.orElseThrow(() -> new ToDoException(SQUAD_TODO_NOT_FOUND));
+		foundSquadToDo.delete();
 	}
 
 }

--- a/src/main/java/com/eggmeonina/scrumble/domain/todo/service/ToDoService.java
+++ b/src/main/java/com/eggmeonina/scrumble/domain/todo/service/ToDoService.java
@@ -1,9 +1,12 @@
 package com.eggmeonina.scrumble.domain.todo.service;
 
-import org.springframework.stereotype.Service;
+import static com.eggmeonina.scrumble.common.exception.ErrorCode.*;
 
-import com.eggmeonina.scrumble.common.exception.ErrorCode;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
 import com.eggmeonina.scrumble.common.exception.MemberException;
+import com.eggmeonina.scrumble.common.exception.ToDoException;
 import com.eggmeonina.scrumble.domain.member.domain.Member;
 import com.eggmeonina.scrumble.domain.member.repository.MemberRepository;
 import com.eggmeonina.scrumble.domain.todo.domain.ToDo;
@@ -13,18 +16,32 @@ import com.eggmeonina.scrumble.domain.todo.repository.TodoRepository;
 import lombok.RequiredArgsConstructor;
 
 @Service
+@Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class ToDoService {
 
 	private final MemberRepository memberRepository;
 	private final TodoRepository todoRepository;
 
+	@Transactional
 	public Long createToDo(Long memberId, SquadTodoCreateRequest request){
 		Member foundMember = memberRepository.findByIdAndMemberStatusNotJOIN(memberId)
-			.orElseThrow(() -> new MemberException(ErrorCode.MEMBER_NOT_FOUND));
+			.orElseThrow(() -> new MemberException(MEMBER_NOT_FOUND));
 
 		ToDo newToDo = SquadTodoCreateRequest.to(request, foundMember);
 		todoRepository.save(newToDo);
 		return newToDo.getId();
+	}
+
+	public boolean isWriter(Long memberId, Long toDoId){
+		return todoRepository.existsByIdAndMemberId(toDoId, memberId);
+	}
+
+	@Transactional
+	public Long deleteToDo(Long toDoId){
+		ToDo foundToDo = todoRepository.findByIdAndDeletedFlagNot(toDoId)
+			.orElseThrow(() -> new ToDoException(TODO_NOT_FOUND));
+		foundToDo.delete();
+		return foundToDo.getId();
 	}
 }

--- a/src/test/java/com/eggmeonina/scrumble/domain/todo/domain/SquadToDoTest.java
+++ b/src/test/java/com/eggmeonina/scrumble/domain/todo/domain/SquadToDoTest.java
@@ -1,0 +1,94 @@
+package com.eggmeonina.scrumble.domain.todo.domain;
+
+import static com.eggmeonina.scrumble.common.exception.ErrorCode.*;
+import static com.eggmeonina.scrumble.fixture.SquadTodoFixture.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.SoftAssertions.*;
+
+import java.time.LocalDate;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.eggmeonina.scrumble.common.exception.SquadToDoException;
+import com.eggmeonina.scrumble.domain.member.domain.Member;
+import com.eggmeonina.scrumble.domain.member.domain.MemberStatus;
+import com.eggmeonina.scrumble.domain.squadmember.domain.Squad;
+
+class SquadToDoTest {
+
+	@Test
+	@DisplayName("스쿼드 투두를 생성한다_성공")
+	void newSquadToDo_success() {
+		// given
+		Member newMember = createMember("testA", "test@test.com", MemberStatus.JOIN, "!23245");
+		Squad newSquad = createSquad("테스트 스쿼드", false);
+		ToDo newToDo = createToDo(newMember, "모각코", TodoStatus.PENDING, false, LocalDate.now());
+
+		// when
+		SquadToDo newSquadToDo = SquadToDo.create()
+			.squad(newSquad)
+			.toDo(newToDo)
+			.deletedFlag(false)
+			.build();
+
+		Squad actualSquad = newSquadToDo.getSquad();
+		ToDo actualToDo = newSquadToDo.getToDo();
+
+		// then
+		assertSoftly(softly -> {
+			softly.assertThat(actualSquad.getSquadName()).isEqualTo(newSquad.getSquadName());
+			softly.assertThat(actualToDo.getToDoType()).isEqualTo(newToDo.getToDoType());
+			softly.assertThat(actualToDo.getContents()).isEqualTo(newToDo.getContents());
+			softly.assertThat(actualToDo.getTodoAt()).isEqualTo(newToDo.getTodoAt());
+		});
+	}
+
+	@Test
+	@DisplayName("스쿼드 없이 스쿼드 투두를 생성한다_실패")
+	void newSquadToDoWhenNotExistsSquad_fail() {
+		// given
+		Member newMember = createMember("testA", "test@test.com", MemberStatus.JOIN, "!23245");
+		ToDo newToDo = createToDo(newMember, "모각코", TodoStatus.PENDING, false, LocalDate.now());
+
+		// when, then
+		assertThatThrownBy(() -> SquadToDo.create()
+			.toDo(newToDo)
+			.deletedFlag(false)
+			.build())
+			.isInstanceOf(SquadToDoException.class)
+			.hasMessageContaining(SQUAD_NOT_FOUND.getMessage());
+	}
+
+	@Test
+	@DisplayName("투두 없이 스쿼드 투두를 생성한다_실패")
+	void newSquadToDoWhenNotExistsToDo_fail() {
+		// given
+		Squad newSquad = createSquad("테스트 스쿼드", false);
+
+		// when, then
+		assertThatThrownBy(() -> SquadToDo.create()
+			.squad(newSquad)
+			.deletedFlag(false)
+			.build())
+			.isInstanceOf(SquadToDoException.class)
+			.hasMessageContaining(TODO_NOT_FOUND.getMessage());
+	}
+
+	@Test
+	@DisplayName("스쿼드를 삭제한다_성공")
+	void delete_success() {
+		// given
+		Member newMember = createMember("testA", "test@test.com", MemberStatus.JOIN, "!23245");
+		Squad newSquad = createSquad("테스트 스쿼드", false);
+		ToDo newToDo = createToDo(newMember, "모각코", TodoStatus.PENDING, false, LocalDate.now());
+		SquadToDo newSquadToDo = createSquadTodo(newSquad, newToDo, false);
+
+		// when
+		newSquadToDo.delete();
+
+		// then
+		assertThat(newSquadToDo.isDeletedFlag()).isTrue();
+	}
+
+}

--- a/src/test/java/com/eggmeonina/scrumble/domain/todo/domain/ToDoTest.java
+++ b/src/test/java/com/eggmeonina/scrumble/domain/todo/domain/ToDoTest.java
@@ -1,0 +1,30 @@
+package com.eggmeonina.scrumble.domain.todo.domain;
+
+import static com.eggmeonina.scrumble.fixture.SquadTodoFixture.*;
+import static org.assertj.core.api.Assertions.*;
+
+import java.time.LocalDate;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.eggmeonina.scrumble.domain.member.domain.Member;
+import com.eggmeonina.scrumble.domain.member.domain.MemberStatus;
+
+class ToDoTest {
+
+	@Test
+	@DisplayName("투두를 삭제한다_성공")
+	void delete_success() {
+		// given
+		Member newMember = createMember("test", "test@test.com", MemberStatus.JOIN, "123235");
+		ToDo newToDo = createToDo(newMember, "모각코", TodoStatus.PENDING, false, LocalDate.now());
+
+		// when
+		newToDo.delete();
+
+		// then
+		assertThat(newToDo.isDeletedFlag()).isTrue();
+	}
+
+}

--- a/src/test/java/com/eggmeonina/scrumble/domain/todo/facade/SquadToDoFacadeServiceIntegrationTest.java
+++ b/src/test/java/com/eggmeonina/scrumble/domain/todo/facade/SquadToDoFacadeServiceIntegrationTest.java
@@ -13,13 +13,16 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 import com.eggmeonina.scrumble.common.exception.MemberException;
 import com.eggmeonina.scrumble.common.exception.SquadException;
+import com.eggmeonina.scrumble.common.exception.ToDoException;
 import com.eggmeonina.scrumble.domain.member.domain.Member;
 import com.eggmeonina.scrumble.domain.member.domain.MemberStatus;
 import com.eggmeonina.scrumble.domain.member.repository.MemberRepository;
 import com.eggmeonina.scrumble.domain.squadmember.domain.Squad;
 import com.eggmeonina.scrumble.domain.squadmember.repository.SquadRepository;
+import com.eggmeonina.scrumble.domain.todo.domain.SquadToDo;
 import com.eggmeonina.scrumble.domain.todo.domain.ToDo;
 import com.eggmeonina.scrumble.domain.todo.domain.ToDoType;
+import com.eggmeonina.scrumble.domain.todo.domain.TodoStatus;
 import com.eggmeonina.scrumble.domain.todo.dto.SquadTodoCreateRequest;
 import com.eggmeonina.scrumble.domain.todo.repository.SquadTodoRepository;
 import com.eggmeonina.scrumble.domain.todo.repository.TodoRepository;
@@ -55,7 +58,8 @@ class SquadToDoFacadeServiceIntegrationTest extends IntegrationTestHelper {
 		SquadTodoCreateRequest request = new SquadTodoCreateRequest(ToDoType.DAILY, "테스트 작성하기", LocalDate.now());
 
 		// when, then
-		assertThatThrownBy(()->squadToDoFacadeService.createToDoAndSquadToDo(newSquad.getId(), newMember.getId(), request))
+		assertThatThrownBy(
+			() -> squadToDoFacadeService.createToDoAndSquadToDo(newSquad.getId(), newMember.getId(), request))
 			.isInstanceOf(SquadException.class)
 			.hasMessageContaining(SQUAD_NOT_FOUND.getMessage());
 		assertThat(todoRepository.count()).isZero();
@@ -100,11 +104,64 @@ class SquadToDoFacadeServiceIntegrationTest extends IntegrationTestHelper {
 		SquadTodoCreateRequest request = new SquadTodoCreateRequest(ToDoType.DAILY, "테스트 작성하기", LocalDate.now());
 
 		// when, then
-		assertThatThrownBy(()->squadToDoFacadeService.createToDoAndSquadToDo(newSquad.getId(), newMember.getId(), request))
+		assertThatThrownBy(
+			() -> squadToDoFacadeService.createToDoAndSquadToDo(newSquad.getId(), newMember.getId(), request))
 			.isInstanceOf(MemberException.class)
 			.hasMessageContaining(MEMBER_NOT_FOUND.getMessage());
 		assertThat(todoRepository.count()).isZero();
 		assertThat(squadTodoRepository.count()).isZero();
+	}
+
+	@Test
+	@DisplayName("스쿼드 투두와 투두를 삭제한다_성공")
+	void deleteToDoAndSquadToDo_success() {
+		// given
+		Member newMember = createMember("memberA", "test@test.com", MemberStatus.WITHDRAW, "12345677");
+		Squad newSquad = createSquad("테스트 스쿼드", false);
+		ToDo newToDo = createToDo(newMember, "모각코", TodoStatus.PENDING, false, LocalDate.now());
+		SquadToDo newSquadToDo = createSquadTodo(newSquad, newToDo, false);
+
+		memberRepository.save(newMember);
+		squadRepository.save(newSquad);
+		todoRepository.save(newToDo);
+		squadTodoRepository.save(newSquadToDo);
+
+		// when
+		squadToDoFacadeService.deleteToDoAndSquadToDo(newSquad.getId(), newToDo.getId(), newMember.getId());
+		ToDo deletedToDo = todoRepository.findById(newToDo.getId()).get();
+		SquadToDo deletedSquadToDo = squadTodoRepository.findById(newSquadToDo.getId()).get();
+
+		// then
+		assertSoftly(softly -> {
+			softly.assertThat(deletedToDo.isDeletedFlag()).isTrue();
+			softly.assertThat(deletedSquadToDo.isDeletedFlag()).isTrue();
+		});
+	}
+
+	@Test
+	@DisplayName("존재하지 않는 투두를 삭제한다_실패")
+	void deleteToDoAndSquadToDoWhenDeletedToDo_fail() {
+		// given
+		Member newMember = createMember("memberA", "test@test.com", MemberStatus.WITHDRAW, "12345677");
+		Squad newSquad = createSquad("테스트 스쿼드", false);
+		ToDo newToDo = createToDo(newMember, "모각코", TodoStatus.PENDING, true, LocalDate.now());
+		SquadToDo newSquadToDo = createSquadTodo(newSquad, newToDo, false);
+
+		memberRepository.save(newMember);
+		squadRepository.save(newSquad);
+		todoRepository.save(newToDo);
+		squadTodoRepository.save(newSquadToDo);
+
+		SquadToDo deletedSquadToDo = squadTodoRepository.findById(newSquadToDo.getId()).get();
+
+		// when, then
+		assertSoftly(softly -> {
+			softly.assertThatThrownBy(
+					() -> squadToDoFacadeService.deleteToDoAndSquadToDo(newSquad.getId(), newToDo.getId(), newMember.getId()))
+				.isInstanceOf(ToDoException.class)
+				.hasMessageContaining(TODO_NOT_FOUND.getMessage());
+			softly.assertThat(deletedSquadToDo.isDeletedFlag()).isFalse();
+		});
 	}
 
 }

--- a/src/test/java/com/eggmeonina/scrumble/domain/todo/service/SquadTodoServiceIntegrationTest.java
+++ b/src/test/java/com/eggmeonina/scrumble/domain/todo/service/SquadTodoServiceIntegrationTest.java
@@ -26,10 +26,13 @@ import com.eggmeonina.scrumble.domain.todo.repository.SquadTodoRepository;
 import com.eggmeonina.scrumble.domain.todo.repository.TodoRepository;
 import com.eggmeonina.scrumble.helper.IntegrationTestHelper;
 
-class SquadTodoServiceIntegrationTest extends IntegrationTestHelper {
+class SquadTodoAndToDoIntegrationTest extends IntegrationTestHelper {
 
 	@Autowired
 	private SquadTodoService squadTodoService;
+
+	@Autowired
+	private ToDoService toDoService;
 
 	@Autowired
 	private SquadTodoRepository squadTodoRepository;
@@ -110,9 +113,43 @@ class SquadTodoServiceIntegrationTest extends IntegrationTestHelper {
 			// then
 			assertThat(squadTodos).hasSize(2);
 		}
-
 	}
 
+	@Test
+	@DisplayName("작성자 여부를 확인한다_성공")
+	void isWriter_success() {
+		// given
+		Member newMember = createMember("testA", "test@test.com", MemberStatus.JOIN, "12335346");
+		ToDo newToDo = createToDo(newMember, "모각코", TodoStatus.PENDING, false, LocalDate.now());
+
+		memberRepository.save(newMember);
+		todoRepository.save(newToDo);
+
+		// when
+		boolean isWriter = toDoService.isWriter(newMember.getId(), newToDo.getId());
+
+		// then
+		assertThat(isWriter).isTrue();
+	}
+
+	@Test
+	@DisplayName("작성자 여부를 확인한다_실패")
+	void isWriter_fail() {
+		// given
+		Member newMember1 = createMember("testA", "test@test.com", MemberStatus.JOIN, "12335346");
+		Member newMember2 = createMember("testA", "test@test.com", MemberStatus.JOIN, "12335346");
+		ToDo newToDo = createToDo(newMember1, "모각코", TodoStatus.PENDING, false, LocalDate.now());
+
+		memberRepository.save(newMember1);
+		memberRepository.save(newMember2);
+		todoRepository.save(newToDo);
+
+		// when
+		boolean isWriter = toDoService.isWriter(newMember2.getId(), newToDo.getId());
+
+		// then
+		assertThat(isWriter).isFalse();
+	}
 
 
 }

--- a/src/test/java/com/eggmeonina/scrumble/domain/todo/service/SquadTodoServiceTest.java
+++ b/src/test/java/com/eggmeonina/scrumble/domain/todo/service/SquadTodoServiceTest.java
@@ -1,0 +1,68 @@
+package com.eggmeonina.scrumble.domain.todo.service;
+
+import static com.eggmeonina.scrumble.common.exception.ErrorCode.*;
+import static com.eggmeonina.scrumble.fixture.SquadTodoFixture.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.*;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.eggmeonina.scrumble.common.exception.ToDoException;
+import com.eggmeonina.scrumble.domain.member.domain.Member;
+import com.eggmeonina.scrumble.domain.member.domain.MemberStatus;
+import com.eggmeonina.scrumble.domain.squadmember.domain.Squad;
+import com.eggmeonina.scrumble.domain.todo.domain.SquadToDo;
+import com.eggmeonina.scrumble.domain.todo.domain.ToDo;
+import com.eggmeonina.scrumble.domain.todo.domain.TodoStatus;
+import com.eggmeonina.scrumble.domain.todo.repository.SquadTodoRepository;
+
+@ExtendWith(MockitoExtension.class)
+class SquadTodoServiceTest {
+
+	@InjectMocks
+	private SquadTodoService squadTodoService;
+
+	@Mock
+	private SquadTodoRepository squadTodoRepository;
+
+	@Test
+	@DisplayName("스쿼드 투두를 삭제한다_성공")
+	void deleteSquadToDo_success() {
+		// given
+		Member newMember = createMember("testA", "test@test.com", MemberStatus.JOIN, "!@335435");
+		Squad newSquad = createSquad("테스트 스쿼드", false);
+		ToDo newToDo = createToDo(newMember, "contents", TodoStatus.PENDING, false, LocalDate.now());
+		SquadToDo newSquadToDo = createSquadTodo(newSquad, newToDo, false);
+		given(squadTodoRepository.findByToDoIdAndSquadIdAndDeletedFlagNot(anyLong(), anyLong()))
+			.willReturn(Optional.ofNullable(newSquadToDo));
+
+		// when
+		squadTodoService.deleteSquadToDo(1L, 1L);
+
+		// then
+		assertThat(newSquadToDo.isDeletedFlag()).isTrue();
+	}
+
+	@Test
+	@DisplayName("삭제된 스쿼드 투두를 삭제한다_실패")
+	void deleteSquadToDoWhenDeletedSquadToDo_fail() {
+		// given
+		given(squadTodoRepository.findByToDoIdAndSquadIdAndDeletedFlagNot(anyLong(), anyLong()))
+			.willReturn(Optional.empty());
+
+		// when, then
+		assertThatThrownBy(()-> squadTodoService.deleteSquadToDo(1L, 1L))
+			.isInstanceOf(ToDoException.class)
+			.hasMessageContaining(SQUAD_TODO_NOT_FOUND.getMessage());
+	}
+
+}

--- a/src/test/java/com/eggmeonina/scrumble/domain/todo/service/ToDoServiceTest.java
+++ b/src/test/java/com/eggmeonina/scrumble/domain/todo/service/ToDoServiceTest.java
@@ -16,10 +16,13 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.eggmeonina.scrumble.common.exception.MemberException;
+import com.eggmeonina.scrumble.common.exception.ToDoException;
 import com.eggmeonina.scrumble.domain.member.domain.Member;
 import com.eggmeonina.scrumble.domain.member.domain.MemberStatus;
 import com.eggmeonina.scrumble.domain.member.repository.MemberRepository;
+import com.eggmeonina.scrumble.domain.todo.domain.ToDo;
 import com.eggmeonina.scrumble.domain.todo.domain.ToDoType;
+import com.eggmeonina.scrumble.domain.todo.domain.TodoStatus;
 import com.eggmeonina.scrumble.domain.todo.dto.SquadTodoCreateRequest;
 import com.eggmeonina.scrumble.domain.todo.repository.TodoRepository;
 
@@ -61,6 +64,36 @@ class ToDoServiceTest {
 		assertThatThrownBy(()-> toDoService.createToDo(1L, request))
 			.isInstanceOf(MemberException.class)
 			.hasMessageContaining(MEMBER_NOT_FOUND.getMessage());
+	}
+
+	@Test
+	@DisplayName("투두를 삭제한다._성공")
+	void deleteToDo_success() {
+		// given
+		Member newMember = createMember("userA", "test@test.com", MemberStatus.JOIN, "!2234235");
+		ToDo newToDo = createToDo(newMember, "모각코", TodoStatus.PENDING, false, LocalDate.now());
+
+		given(todoRepository.findByIdAndDeletedFlagNot(anyLong()))
+			.willReturn(Optional.ofNullable(newToDo));
+
+		// when
+		toDoService.deleteToDo(1L);
+
+		// then
+		assertThat(newToDo.isDeletedFlag()).isTrue();
+	}
+
+	@Test
+	@DisplayName("없거나 삭제된 투두를 삭제한다_실패")
+	void deleteToDoWhenDeletedToDo_success() {
+		// given
+		given(todoRepository.findByIdAndDeletedFlagNot(anyLong()))
+			.willReturn(Optional.empty());
+
+		// when, then
+		assertThatThrownBy(()->toDoService.deleteToDo(1L))
+			.isInstanceOf(ToDoException.class)
+			.hasMessageContaining(TODO_NOT_FOUND.getMessage());
 	}
 
 }


### PR DESCRIPTION
## 관련 이슈
#88 

## 작업 사항
<!-- 가장 대표적인 작업 내용 -->
스쿼드에 속한 ToDo를 삭제합니다.

### 추가 정보
<!-- 이 PR에 대한 추가적인 정보가 필요하다면 작성해주세요. -->
- 삭제 요청 시, ToDo와 스쿼드에 속한 ToDo를 모두 삭제한다.
- 본인의 ToDo만 삭제할 수 있다.
