### PR TITLE
Feat: 나의 Todo 리스트 조회 기능 개발

### DIFF
--- a/src/main/java/com/eggmeonina/scrumble/domain/auth/facade/AuthFacadeService.java
+++ b/src/main/java/com/eggmeonina/scrumble/domain/auth/facade/AuthFacadeService.java
@@ -33,7 +33,6 @@ public class AuthFacadeService {
 		if(authClient == null){
 			throw new AuthException(TYPE_NOT_SUPPORTED);
 		}
-		if(authClient != null){}
 		GoogleAuthClientResponse accessToken = authClient.getAccessToken(request.getCode(), request.getScope());
 		String token = String.format("%s %s", accessToken.getTokenType(), accessToken.getAccessToken());
 		MemberInformation foundMemberInformation = authClient.findUserProfile(token);

--- a/src/main/java/com/eggmeonina/scrumble/domain/todo/controller/TodoController.java
+++ b/src/main/java/com/eggmeonina/scrumble/domain/todo/controller/TodoController.java
@@ -20,6 +20,8 @@ import com.eggmeonina.scrumble.domain.auth.dto.LoginMember;
 import com.eggmeonina.scrumble.domain.todo.dto.SquadTodoCreateRequest;
 import com.eggmeonina.scrumble.domain.todo.dto.SquadTodoRequest;
 import com.eggmeonina.scrumble.domain.todo.dto.SquadTodoResponse;
+import com.eggmeonina.scrumble.domain.todo.dto.ToDoRequest;
+import com.eggmeonina.scrumble.domain.todo.dto.ToDoResponse;
 import com.eggmeonina.scrumble.domain.todo.dto.ToDoUpdateRequest;
 import com.eggmeonina.scrumble.domain.todo.facade.SquadToDoFacadeService;
 import com.eggmeonina.scrumble.domain.todo.service.SquadTodoService;
@@ -28,6 +30,7 @@ import com.eggmeonina.scrumble.domain.todo.service.ToDoService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 @Tag(name = "Todo 테스트", description = "todo 생성, 삭제, 조회용 API Controller")
@@ -81,6 +84,16 @@ public class TodoController {
 	){
 		toDoService.updateToDo(member.getMemberId(), toDoId, request);
 		return ApiResponse.createSuccessWithNoContentResponse(HttpStatus.OK.value());
+	}
+
+	@GetMapping("/me")
+	@Operation(summary = "나의 투두들을 조회한다", description = "내가 작성한 투두들을 조회한다.")
+	public ApiResponse<List<ToDoResponse>> getToDos(
+		@Valid @ModelAttribute ToDoRequest request,
+		@Parameter(hidden = true) @Member LoginMember member
+	){
+		List<ToDoResponse> toDos = toDoService.findToDos(member.getMemberId(), request);
+		return ApiResponse.createSuccessResponse(HttpStatus.OK.value(), toDos);
 	}
 
 }

--- a/src/main/java/com/eggmeonina/scrumble/domain/todo/dto/ToDoDetailResponse.java
+++ b/src/main/java/com/eggmeonina/scrumble/domain/todo/dto/ToDoDetailResponse.java
@@ -1,0 +1,31 @@
+package com.eggmeonina.scrumble.domain.todo.dto;
+
+import java.time.LocalDate;
+
+import com.eggmeonina.scrumble.domain.todo.domain.TodoStatus;
+import com.querydsl.core.annotations.QueryProjection;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class ToDoDetailResponse {
+	private Long toDoId;
+	private Long squadId;
+	private String squadName;
+	private String contents;
+	private LocalDate todoAt;
+	private TodoStatus todoStatus;
+
+	@QueryProjection
+	public ToDoDetailResponse(Long toDoId, Long squadId, String squadName, String contents, LocalDate todoAt,
+		TodoStatus todoStatus) {
+		this.toDoId = toDoId;
+		this.squadId = squadId;
+		this.squadName = squadName;
+		this.contents = contents;
+		this.todoAt = todoAt;
+		this.todoStatus = todoStatus;
+	}
+}

--- a/src/main/java/com/eggmeonina/scrumble/domain/todo/dto/ToDoRequest.java
+++ b/src/main/java/com/eggmeonina/scrumble/domain/todo/dto/ToDoRequest.java
@@ -3,6 +3,7 @@ package com.eggmeonina.scrumble.domain.todo.dto;
 import java.time.LocalDate;
 
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -15,4 +16,6 @@ public class ToDoRequest {
 	private LocalDate endDate;
 	@NotNull
 	private Long lastToDoId;
+	@Positive
+	private long pageSize;
 }

--- a/src/main/java/com/eggmeonina/scrumble/domain/todo/dto/ToDoRequest.java
+++ b/src/main/java/com/eggmeonina/scrumble/domain/todo/dto/ToDoRequest.java
@@ -1,0 +1,18 @@
+package com.eggmeonina.scrumble.domain.todo.dto;
+
+import java.time.LocalDate;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ToDoRequest {
+	@NotNull
+	private LocalDate startDate;
+	@NotNull
+	private LocalDate endDate;
+	@NotNull
+	private Long lastToDoId;
+}

--- a/src/main/java/com/eggmeonina/scrumble/domain/todo/dto/ToDoResponse.java
+++ b/src/main/java/com/eggmeonina/scrumble/domain/todo/dto/ToDoResponse.java
@@ -1,0 +1,22 @@
+package com.eggmeonina.scrumble.domain.todo.dto;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import com.querydsl.core.annotations.QueryProjection;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class ToDoResponse {
+	private LocalDate toDoAt;
+	private List<ToDoDetailResponse> toDoDetails;
+
+	@QueryProjection
+	public ToDoResponse(LocalDate toDoAt, List<ToDoDetailResponse> toDoDetails) {
+		this.toDoAt = toDoAt;
+		this.toDoDetails = toDoDetails;
+	}
+}

--- a/src/main/java/com/eggmeonina/scrumble/domain/todo/repository/ToDoRepositoryCustom.java
+++ b/src/main/java/com/eggmeonina/scrumble/domain/todo/repository/ToDoRepositoryCustom.java
@@ -1,0 +1,10 @@
+package com.eggmeonina.scrumble.domain.todo.repository;
+
+import java.util.List;
+
+import com.eggmeonina.scrumble.domain.todo.dto.ToDoRequest;
+import com.eggmeonina.scrumble.domain.todo.dto.ToDoResponse;
+
+public interface ToDoRepositoryCustom {
+	List<ToDoResponse> findAll(Long memberId, ToDoRequest request);
+}

--- a/src/main/java/com/eggmeonina/scrumble/domain/todo/repository/TodoRepository.java
+++ b/src/main/java/com/eggmeonina/scrumble/domain/todo/repository/TodoRepository.java
@@ -7,7 +7,7 @@ import org.springframework.data.jpa.repository.Query;
 
 import com.eggmeonina.scrumble.domain.todo.domain.ToDo;
 
-public interface TodoRepository extends JpaRepository<ToDo, Long> {
+public interface TodoRepository extends JpaRepository<ToDo, Long>, ToDoRepositoryCustom {
 
 	@Query("""
 		SELECT t

--- a/src/main/java/com/eggmeonina/scrumble/domain/todo/repository/impl/ToDoRepositoryCustomImpl.java
+++ b/src/main/java/com/eggmeonina/scrumble/domain/todo/repository/impl/ToDoRepositoryCustomImpl.java
@@ -26,6 +26,7 @@ public class ToDoRepositoryCustomImpl implements ToDoRepositoryCustom {
 
 	@Override
 	public List<ToDoResponse> findAll(Long memberId, ToDoRequest request) {
+
 		return query.selectFrom(toDo)
 			.join(toDo.member)
 			.join(squadToDo)
@@ -37,6 +38,7 @@ public class ToDoRepositoryCustomImpl implements ToDoRepositoryCustom {
 			.and(toDo.member.id.eq(memberId))
 				.and(toDo.todoAt.between(request.getStartDate(), request.getEndDate()))
 				.and(toDo.deletedFlag.eq(false)))
+			.limit(request.getPageSize())
 			.orderBy(toDo.todoAt.desc(), toDo.id.desc())
 			.transform(
 				groupBy(toDo.todoAt).list(

--- a/src/main/java/com/eggmeonina/scrumble/domain/todo/repository/impl/ToDoRepositoryCustomImpl.java
+++ b/src/main/java/com/eggmeonina/scrumble/domain/todo/repository/impl/ToDoRepositoryCustomImpl.java
@@ -1,0 +1,49 @@
+package com.eggmeonina.scrumble.domain.todo.repository.impl;
+
+import static com.eggmeonina.scrumble.domain.squadmember.domain.QSquad.*;
+import static com.eggmeonina.scrumble.domain.todo.domain.QSquadToDo.*;
+import static com.eggmeonina.scrumble.domain.todo.domain.QToDo.*;
+import static com.querydsl.core.group.GroupBy.*;
+
+import java.util.List;
+
+import org.springframework.stereotype.Repository;
+
+import com.eggmeonina.scrumble.domain.todo.dto.QToDoDetailResponse;
+import com.eggmeonina.scrumble.domain.todo.dto.QToDoResponse;
+import com.eggmeonina.scrumble.domain.todo.dto.ToDoRequest;
+import com.eggmeonina.scrumble.domain.todo.dto.ToDoResponse;
+import com.eggmeonina.scrumble.domain.todo.repository.ToDoRepositoryCustom;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class ToDoRepositoryCustomImpl implements ToDoRepositoryCustom {
+
+	private final JPAQueryFactory query;
+
+	@Override
+	public List<ToDoResponse> findAll(Long memberId, ToDoRequest request) {
+		return query.selectFrom(toDo)
+			.join(toDo.member)
+			.join(squadToDo)
+			.on(squadToDo.toDo.id.eq(toDo.id)
+				.and(squadToDo.deletedFlag.eq(false)))
+			.join(squad)
+			.on(squad.id.eq(squadToDo.squad.id))
+			.where(toDo.id.lt(request.getLastToDoId())
+			.and(toDo.member.id.eq(memberId))
+				.and(toDo.todoAt.between(request.getStartDate(), request.getEndDate()))
+				.and(toDo.deletedFlag.eq(false)))
+			.orderBy(toDo.todoAt.desc(), toDo.id.desc())
+			.transform(
+				groupBy(toDo.todoAt).list(
+					new QToDoResponse(toDo.todoAt, list(
+						new QToDoDetailResponse(toDo.id, squad.id, squad.squadName, toDo.contents, toDo.todoAt, toDo.todoStatus)
+					))
+				)
+			);
+	}
+}

--- a/src/main/java/com/eggmeonina/scrumble/domain/todo/service/ToDoService.java
+++ b/src/main/java/com/eggmeonina/scrumble/domain/todo/service/ToDoService.java
@@ -2,6 +2,8 @@ package com.eggmeonina.scrumble.domain.todo.service;
 
 import static com.eggmeonina.scrumble.common.exception.ErrorCode.*;
 
+import java.util.List;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -11,6 +13,8 @@ import com.eggmeonina.scrumble.domain.member.domain.Member;
 import com.eggmeonina.scrumble.domain.member.repository.MemberRepository;
 import com.eggmeonina.scrumble.domain.todo.domain.ToDo;
 import com.eggmeonina.scrumble.domain.todo.dto.SquadTodoCreateRequest;
+import com.eggmeonina.scrumble.domain.todo.dto.ToDoRequest;
+import com.eggmeonina.scrumble.domain.todo.dto.ToDoResponse;
 import com.eggmeonina.scrumble.domain.todo.dto.ToDoUpdateRequest;
 import com.eggmeonina.scrumble.domain.todo.repository.TodoRepository;
 
@@ -54,5 +58,9 @@ public class ToDoService {
 		ToDo foundToDo = todoRepository.findByIdAndDeletedFlagNot(toDoId)
 			.orElseThrow(() -> new ToDoException(TODO_NOT_FOUND));
 		foundToDo.update(request.getContents(), request.getToDoStatus(), request.getToDoAt());
+	}
+
+	public List<ToDoResponse> findToDos(Long memberId, ToDoRequest request){
+		return todoRepository.findAll(memberId, request);
 	}
 }

--- a/src/main/resources/db/h2/data.sql
+++ b/src/main/resources/db/h2/data.sql
@@ -16,7 +16,13 @@ values (default, 'DAILY', '테스트 투두', 'PENDING', now(), false, 1, now())
 insert into todo(todo_id, todo_type, contents, todo_status, todo_at, deleted_flag, member_id, created_at)
 values (default, 'DAILY', '삭제된 투두', 'PENDING', now(), true, 1, now());
 insert into todo(todo_id, todo_type, contents, todo_status, todo_at, deleted_flag, member_id, created_at)
-values (default, 'DAILY', '완료된 투두', 'COMPLETED', now(), false, 1, now());
+values (default, 'DAILY', 'CS', 'COMPLETED', now(), false, 1, now());
+insert into todo(todo_id, todo_type, contents, todo_status, todo_at, deleted_flag, member_id, created_at)
+values (default, 'DAILY', '프로젝트', 'PENDING', now(), false, 1, now());
+insert into todo(todo_id, todo_type, contents, todo_status, todo_at, deleted_flag, member_id, created_at)
+values (default, 'DAILY', '알고리즘', 'PENDING', now(), false, 1, now());
+insert into todo(todo_id, todo_type, contents, todo_status, todo_at, deleted_flag, member_id, created_at)
+values (default, 'DAILY', '알고리즘', 'PENDING', DATEADD('DAY', -1, NOW()), false, 1, now());
 
 insert into squad_todo(squad_todo_id, todo_id, squad_id, deleted_flag, created_at)
 values (default, 1, 1, 0, now());
@@ -24,3 +30,9 @@ insert into squad_todo(squad_todo_id, todo_id, squad_id, deleted_flag, created_a
 values (default, 2, 1, 0, now());
 insert into squad_todo(squad_todo_id, todo_id, squad_id, deleted_flag, created_at)
 values (default, 3, 1, 0, now());
+insert into squad_todo(squad_todo_id, todo_id, squad_id, deleted_flag, created_at)
+values (default, 4, 1, 0, now());
+insert into squad_todo(squad_todo_id, todo_id, squad_id, deleted_flag, created_at)
+values (default, 5, 1, 0, now());
+insert into squad_todo(squad_todo_id, todo_id, squad_id, deleted_flag, created_at)
+values (default, 6, 1, 0, now());

--- a/src/test/java/com/eggmeonina/scrumble/domain/todo/service/ToDoServiceIntegrationTest.java
+++ b/src/test/java/com/eggmeonina/scrumble/domain/todo/service/ToDoServiceIntegrationTest.java
@@ -1,0 +1,165 @@
+package com.eggmeonina.scrumble.domain.todo.service;
+
+import static com.eggmeonina.scrumble.fixture.SquadTodoFixture.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.SoftAssertions.*;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import com.eggmeonina.scrumble.domain.member.domain.Member;
+import com.eggmeonina.scrumble.domain.member.domain.MemberStatus;
+import com.eggmeonina.scrumble.domain.member.repository.MemberRepository;
+import com.eggmeonina.scrumble.domain.squadmember.domain.Squad;
+import com.eggmeonina.scrumble.domain.squadmember.repository.SquadRepository;
+import com.eggmeonina.scrumble.domain.todo.domain.SquadToDo;
+import com.eggmeonina.scrumble.domain.todo.domain.ToDo;
+import com.eggmeonina.scrumble.domain.todo.domain.TodoStatus;
+import com.eggmeonina.scrumble.domain.todo.dto.ToDoRequest;
+import com.eggmeonina.scrumble.domain.todo.dto.ToDoResponse;
+import com.eggmeonina.scrumble.domain.todo.repository.SquadTodoRepository;
+import com.eggmeonina.scrumble.domain.todo.repository.TodoRepository;
+import com.eggmeonina.scrumble.helper.IntegrationTestHelper;
+
+class ToDoServiceIntegrationTest extends IntegrationTestHelper {
+
+	@Autowired
+	private ToDoService toDoService;
+
+	@Autowired
+	private TodoRepository todoRepository;
+
+	@Autowired
+	private MemberRepository memberRepository;
+
+	@Autowired
+	private SquadTodoRepository squadTodoRepository;
+
+	@Autowired
+	private SquadRepository squadRepository;
+
+
+	@Nested
+	@DisplayName("나의 투두 리스트를 조회한다")
+	class findToDos{
+		@Test
+		@DisplayName("투두가 1개일 때_성공")
+		void whenExistsOne_success() {
+			// given
+			Member newMember = createMember("test", "test@test.com", MemberStatus.JOIN, "123234");
+			Squad newSquad = createSquad("스쿼드1", false);
+			ToDo newToDo = createToDo(newMember, "여행", TodoStatus.PENDING, false, LocalDate.now());
+			SquadToDo newSquadToDo = createSquadTodo(newSquad, newToDo, false);
+
+			memberRepository.save(newMember);
+			squadRepository.save(newSquad);
+			todoRepository.save(newToDo);
+			squadTodoRepository.save(newSquadToDo);
+
+			ToDoRequest request = new ToDoRequest(LocalDate.now(), LocalDate.now(), 9999999L);
+
+			// when
+			List<ToDoResponse> toDos = toDoService.findToDos(newMember.getId(), request);
+
+			// then
+			assertThat(toDos).hasSize(1);
+		}
+
+		@Test
+		@DisplayName("투두가 N개일 때_성공")
+		void whenExistToDos_success() {
+			// given
+			Member newMember = createMember("test", "test@test.com", MemberStatus.JOIN, "123234");
+			Squad newSquad = createSquad("스쿼드1", false);
+			ToDo newToDo1 = createToDo(newMember, "여행", TodoStatus.PENDING, false, LocalDate.now());
+			ToDo newToDo2 = createToDo(newMember, "프로젝트", TodoStatus.PENDING, false, LocalDate.now());
+			ToDo newToDo3 = createToDo(newMember, "알고리즘", TodoStatus.PENDING, false, LocalDate.now());
+			SquadToDo newSquadToDo1 = createSquadTodo(newSquad, newToDo1, false);
+			SquadToDo newSquadToDo2 = createSquadTodo(newSquad, newToDo2, false);
+			SquadToDo newSquadToDo3 = createSquadTodo(newSquad, newToDo3, false);
+
+			memberRepository.save(newMember);
+			squadRepository.save(newSquad);
+			todoRepository.saveAll(List.of(newToDo1, newToDo2, newToDo3));
+			squadTodoRepository.saveAll(List.of(newSquadToDo1, newSquadToDo2, newSquadToDo3));
+
+			ToDoRequest request = new ToDoRequest(LocalDate.now(), LocalDate.now(), 9999999L);
+
+			// when
+			List<ToDoResponse> toDos = toDoService.findToDos(newMember.getId(), request);
+
+			// then
+			assertThat(toDos).hasSize(1);
+			assertThat(toDos.get(0).getToDoDetails()).hasSize(3);
+		}
+
+		@Test
+		@DisplayName("스쿼드가 N개일 때_성공")
+		void whenExistSquads_success() {
+			// given
+			Member newMember = createMember("test", "test@test.com", MemberStatus.JOIN, "123234");
+			Squad newSquad1 = createSquad("스쿼드1", false);
+			Squad newSquad2 = createSquad("두번째 스쿼드", false);
+			ToDo newToDo1 = createToDo(newMember, "여행", TodoStatus.PENDING, false, LocalDate.now());
+			ToDo newToDo2 = createToDo(newMember, "프로젝트", TodoStatus.PENDING, false, LocalDate.now());
+			ToDo newToDo3 = createToDo(newMember, "알고리즘", TodoStatus.PENDING, false, LocalDate.now());
+			SquadToDo newSquadToDo1 = createSquadTodo(newSquad1, newToDo1, false);
+			SquadToDo newSquadToDo2 = createSquadTodo(newSquad2, newToDo2, false);
+			SquadToDo newSquadToDo3 = createSquadTodo(newSquad1, newToDo3, false);
+
+			memberRepository.save(newMember);
+			squadRepository.save(newSquad1);
+			squadRepository.save(newSquad2);
+			todoRepository.saveAll(List.of(newToDo1, newToDo2, newToDo3));
+			squadTodoRepository.saveAll(List.of(newSquadToDo1, newSquadToDo2, newSquadToDo3));
+
+			ToDoRequest request = new ToDoRequest(LocalDate.now(), LocalDate.now(), 9999999L);
+
+			// when
+			List<ToDoResponse> toDos = toDoService.findToDos(newMember.getId(), request);
+
+			// then
+			assertThat(toDos).hasSize(1);
+			assertThat(toDos.get(0).getToDoDetails()).hasSize(3);
+		}
+
+		@Test
+		@DisplayName("날짜가 여러개일 때_성공")
+		void whenExistDays_success() {
+			// given
+			Member newMember = createMember("test", "test@test.com", MemberStatus.JOIN, "123234");
+			Squad newSquad1 = createSquad("스쿼드1", false);
+			Squad newSquad2 = createSquad("두번째 스쿼드", false);
+			ToDo newToDo1 = createToDo(newMember, "여행", TodoStatus.PENDING, false, LocalDate.now().minusDays(1));
+			ToDo newToDo2 = createToDo(newMember, "프로젝트", TodoStatus.PENDING, false, LocalDate.now());
+			ToDo newToDo3 = createToDo(newMember, "알고리즘", TodoStatus.PENDING, false, LocalDate.now());
+			SquadToDo newSquadToDo1 = createSquadTodo(newSquad1, newToDo1, false);
+			SquadToDo newSquadToDo2 = createSquadTodo(newSquad2, newToDo2, false);
+			SquadToDo newSquadToDo3 = createSquadTodo(newSquad1, newToDo3, false);
+
+			memberRepository.save(newMember);
+			squadRepository.save(newSquad1);
+			squadRepository.save(newSquad2);
+			todoRepository.saveAll(List.of(newToDo1, newToDo2, newToDo3));
+			squadTodoRepository.saveAll(List.of(newSquadToDo1, newSquadToDo2, newSquadToDo3));
+
+			ToDoRequest request = new ToDoRequest(LocalDate.now().minusDays(1), LocalDate.now(), 9999999L);
+
+			// when
+			List<ToDoResponse> toDos = toDoService.findToDos(newMember.getId(), request);
+
+			// then
+			assertSoftly(softly -> {
+				softly.assertThat(toDos).hasSize(2);
+				assertThat(toDos.get(0).getToDoDetails()).hasSize(2);
+				assertThat(toDos.get(1).getToDoDetails()).hasSize(1);
+			});
+		}
+	}
+
+}

--- a/src/test/java/com/eggmeonina/scrumble/domain/todo/service/ToDoServiceIntegrationTest.java
+++ b/src/test/java/com/eggmeonina/scrumble/domain/todo/service/ToDoServiceIntegrationTest.java
@@ -61,7 +61,7 @@ class ToDoServiceIntegrationTest extends IntegrationTestHelper {
 			todoRepository.save(newToDo);
 			squadTodoRepository.save(newSquadToDo);
 
-			ToDoRequest request = new ToDoRequest(LocalDate.now(), LocalDate.now(), 9999999L);
+			ToDoRequest request = new ToDoRequest(LocalDate.now(), LocalDate.now(), 9999999L, 50L);
 
 			// when
 			List<ToDoResponse> toDos = toDoService.findToDos(newMember.getId(), request);
@@ -88,7 +88,7 @@ class ToDoServiceIntegrationTest extends IntegrationTestHelper {
 			todoRepository.saveAll(List.of(newToDo1, newToDo2, newToDo3));
 			squadTodoRepository.saveAll(List.of(newSquadToDo1, newSquadToDo2, newSquadToDo3));
 
-			ToDoRequest request = new ToDoRequest(LocalDate.now(), LocalDate.now(), 9999999L);
+			ToDoRequest request = new ToDoRequest(LocalDate.now(), LocalDate.now(), 9999999L, 50L);
 
 			// when
 			List<ToDoResponse> toDos = toDoService.findToDos(newMember.getId(), request);
@@ -118,7 +118,7 @@ class ToDoServiceIntegrationTest extends IntegrationTestHelper {
 			todoRepository.saveAll(List.of(newToDo1, newToDo2, newToDo3));
 			squadTodoRepository.saveAll(List.of(newSquadToDo1, newSquadToDo2, newSquadToDo3));
 
-			ToDoRequest request = new ToDoRequest(LocalDate.now(), LocalDate.now(), 9999999L);
+			ToDoRequest request = new ToDoRequest(LocalDate.now(), LocalDate.now(), 9999999L, 50L);
 
 			// when
 			List<ToDoResponse> toDos = toDoService.findToDos(newMember.getId(), request);
@@ -148,7 +148,7 @@ class ToDoServiceIntegrationTest extends IntegrationTestHelper {
 			todoRepository.saveAll(List.of(newToDo1, newToDo2, newToDo3));
 			squadTodoRepository.saveAll(List.of(newSquadToDo1, newSquadToDo2, newSquadToDo3));
 
-			ToDoRequest request = new ToDoRequest(LocalDate.now().minusDays(1), LocalDate.now(), 9999999L);
+			ToDoRequest request = new ToDoRequest(LocalDate.now().minusDays(1), LocalDate.now(), 9999999L, 50L);
 
 			// when
 			List<ToDoResponse> toDos = toDoService.findToDos(newMember.getId(), request);
@@ -160,6 +160,72 @@ class ToDoServiceIntegrationTest extends IntegrationTestHelper {
 				assertThat(toDos.get(1).getToDoDetails()).hasSize(1);
 			});
 		}
+	}
+
+	@Nested
+	@DisplayName("노 오프셋 페이징 테스트")
+	class no_offset_paging{
+
+		@Test
+		@DisplayName("페이징 크기보다 많을 때 페이징 크기만큼 조회한다")
+		void whenGreaterThanPageSize_success() {
+			// given
+			Member newMember = createMember("test", "test@test.com", MemberStatus.JOIN, "123234");
+			Squad newSquad1 = createSquad("스쿼드1", false);
+			Squad newSquad2 = createSquad("두번째 스쿼드", false);
+			ToDo newToDo1 = createToDo(newMember, "여행", TodoStatus.PENDING, false, LocalDate.now());
+			ToDo newToDo2 = createToDo(newMember, "프로젝트", TodoStatus.PENDING, false, LocalDate.now());
+			ToDo newToDo3 = createToDo(newMember, "알고리즘", TodoStatus.PENDING, false, LocalDate.now());
+			ToDo newToDo4 = createToDo(newMember, "알고리즘", TodoStatus.PENDING, false, LocalDate.now());
+			SquadToDo newSquadToDo1 = createSquadTodo(newSquad1, newToDo1, false);
+			SquadToDo newSquadToDo2 = createSquadTodo(newSquad2, newToDo2, false);
+			SquadToDo newSquadToDo3 = createSquadTodo(newSquad1, newToDo3, false);
+			SquadToDo newSquadToDo4 = createSquadTodo(newSquad1, newToDo4, false);
+
+			memberRepository.save(newMember);
+			squadRepository.save(newSquad1);
+			squadRepository.save(newSquad2);
+			todoRepository.saveAll(List.of(newToDo1, newToDo2, newToDo3, newToDo4));
+			squadTodoRepository.saveAll(List.of(newSquadToDo1, newSquadToDo2, newSquadToDo3, newSquadToDo4));
+
+			int pageSize = 3;
+			ToDoRequest request = new ToDoRequest(LocalDate.now().minusDays(1), LocalDate.now(), 9999999L, pageSize);
+
+			// when
+			List<ToDoResponse> toDos = toDoService.findToDos(newMember.getId(), request);
+
+			// then
+			assertThat(toDos.get(0).getToDoDetails()).hasSize(3);
+		}
+
+		@Test
+		@DisplayName("페이징 크기보다 적을 때 페이징 크기만큼 조회한다")
+		void whenLessThanPageSize_success() {
+			// given
+			Member newMember = createMember("test", "test@test.com", MemberStatus.JOIN, "123234");
+			Squad newSquad1 = createSquad("스쿼드1", false);
+			Squad newSquad2 = createSquad("두번째 스쿼드", false);
+			ToDo newToDo1 = createToDo(newMember, "여행", TodoStatus.PENDING, false, LocalDate.now());
+			ToDo newToDo2 = createToDo(newMember, "프로젝트", TodoStatus.PENDING, false, LocalDate.now());
+			SquadToDo newSquadToDo1 = createSquadTodo(newSquad1, newToDo1, false);
+			SquadToDo newSquadToDo2 = createSquadTodo(newSquad2, newToDo2, false);
+
+			memberRepository.save(newMember);
+			squadRepository.save(newSquad1);
+			squadRepository.save(newSquad2);
+			todoRepository.saveAll(List.of(newToDo1, newToDo2));
+			squadTodoRepository.saveAll(List.of(newSquadToDo1, newSquadToDo2));
+
+			int pageSize = 3;
+			ToDoRequest request = new ToDoRequest(LocalDate.now().minusDays(1), LocalDate.now(), 9999999L, pageSize);
+
+			// when
+			List<ToDoResponse> toDos = toDoService.findToDos(newMember.getId(), request);
+
+			// then
+			assertThat(toDos.get(0).getToDoDetails()).hasSize(2);
+		}
+
 	}
 
 }


### PR DESCRIPTION
## 관련 이슈
#90 

## 작업 사항
<!-- 가장 대표적인 작업 내용 -->
나의 ToDo 리스트 조회 기능을 추가하였습니다.

### 추가 정보
스쿼드별, 일자별 Todo 리스트를 조회한다.

응답 포맷
``` 
{
  "statusCodeValue": 0,
  "message": "string",
  "data": [
     {
      todoAt : 2024-10-04
      data : [
                 {
                   squadId : 0,
                   squadName : "string",
                   todoId : 0,
                   todoAt : 2024-10-04,
                   todoContents : "string",
                   todoStatus : "PENDING"
                 },
                 {
                   squadId : 0,
                   squadName : "string",
                   todoId : 0,
                   todoAt : 2024-10-04,
                   todoContents : "string",
                   todoStatus : "PENDING"
                 }
             ]
     },
  ]
}
```
