### PR TITLE
Fix: CORS 허용 메소드 추가

### DIFF
--- a/src/main/java/com/eggmeonina/scrumble/common/config/CorsConfig.java
+++ b/src/main/java/com/eggmeonina/scrumble/common/config/CorsConfig.java
@@ -1,5 +1,7 @@
 package com.eggmeonina.scrumble.common.config;
 
+import static org.springframework.http.HttpMethod.*;
+
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
@@ -22,6 +24,12 @@ public class CorsConfig implements WebMvcConfigurer {
 	public void addCorsMappings(CorsRegistry registry) {
 		registry.addMapping("/api/**")
 			.allowedOrigins(corsProperties.getOriginArr())
+			.allowedMethods(
+				GET.name(),
+				HEAD.name(),
+				POST.name(),
+				PUT.name(),
+				DELETE.name())
 			.allowCredentials(true);
 	}
 }


### PR DESCRIPTION
## 관련 이슈
#133

## 작업 사항
<!-- 가장 대표적인 작업 내용 -->
CORS 허용 메소드를 추가합니다.

### 추가 정보
<!-- 이 PR에 대한 추가적인 정보가 필요하다면 작성해주세요. -->
CORS 허용 메소드를 추가하지 않으면 디폴트인 `POST, GET`만 정상적으로 처리됩니다. 이에 따라 `PUT, DELETE, PATCH` 메소드도 허용합니다.
