### PR TITLE
Chore: 개발서버 db 스키마 초기화 설정 제거

### DIFF
--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -17,12 +17,6 @@ spring:
     properties:
       hibernate.format_sql: true
 
-  sql:
-    init:
-      schema-locations: classpath:db/mysql/schema.sql
-      data-locations: classpath:db/mysql/data.sql
-      mode: always                                  # 서버 재기동 마다 schema, data 새로 생성
-
 springdoc:
   version: '@project.version@'
   api-docs:


### PR DESCRIPTION
## 관련 이슈
close : #171 

## 작업 사항
<!-- 가장 대표적인 작업 내용 -->
편의를 위해 서버를 재시작할 때마다 스키마가 초기화 설정을 했었습니다. 현재는 불필요하여 개발서버 db 스키마 초기화 설정을 제거합니다.

### 추가 정보
<!-- 이 PR에 대한 추가적인 정보가 필요하다면 작성해주세요. -->
