### PR TITLE
Chore: 개발 환경에 세션 쿠키 same-site none으로 설정

### DIFF
--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -31,3 +31,11 @@ springdoc:
     doc-expansion: none
   paths-to-match:
     - /** # /api/**로 시작하는 모든 경로가 문서화된다.
+
+
+server:
+  servlet:
+    session:
+      cookie:
+        same-site: "none"
+        secure: true


### PR DESCRIPTION
## 관련 이슈
closes : #180 

## 작업 사항
<!-- 가장 대표적인 작업 내용 -->
백엔드와 프론트 간의 origin이 달라서 CORS 설정을 추가 했었습니다. 세션 쿠키 역시 same-site가 lax로 설정되어 클라이언트에서 세션 쿠키가 저장되지 않는 문제가 발생하였습니다.
해결하기 위해 개발 환경에서 세션 쿠키의 same-site 설정 및 secure 설정을 추가하였습니다.

### 스크린샷 (해당되는 경우)
<!-- UI 변경 사항이 있는 경우, 스크린샷을 첨부해주세요. -->
![스크린샷 2024-10-24 오후 6 59 02](https://github.com/user-attachments/assets/3bd72a76-02cf-4cf7-870e-4590df97fa86)

### 추가 정보
<!-- 이 PR에 대한 추가적인 정보가 필요하다면 작성해주세요. -->
