### PR TITLE
Feat: 회원의 Notification 목록 조회 기능 개발 (#166)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,6 +53,9 @@ dependencies {
     annotationProcessor 'com.querydsl:querydsl-apt:5.0.0:jakarta'
     annotationProcessor 'jakarta.annotation:jakarta.annotation-api'
     annotationProcessor 'jakarta.persistence:jakarta.persistence-api'
+
+    // gson
+    implementation 'com.google.code.gson:gson:2.10.1'
 }
 
 def generated = 'src/main/generated'

--- a/src/main/java/com/eggmeonina/scrumble/common/exception/ErrorCode.java
+++ b/src/main/java/com/eggmeonina/scrumble/common/exception/ErrorCode.java
@@ -50,7 +50,8 @@ public enum ErrorCode {
 	/**
 	 * 알림
 	 */
-	NOTIFICATION_TYPE_NOT_NULL(HttpStatus.BAD_REQUEST, "알림 타입은 비어있을 수 없습니다.");
+	NOTIFICATION_TYPE_NOT_NULL(HttpStatus.BAD_REQUEST, "알림 타입은 비어있을 수 없습니다."),
+	NOTIFICATION_TYPE_NOT_EXISTS(HttpStatus.BAD_REQUEST, "존재하지 않는 알림 타입입니다.");
 
 	private final HttpStatus status;
 	private final String message;

--- a/src/main/java/com/eggmeonina/scrumble/common/util/JsonToNotificationMessageConverter.java
+++ b/src/main/java/com/eggmeonina/scrumble/common/util/JsonToNotificationMessageConverter.java
@@ -1,0 +1,44 @@
+package com.eggmeonina.scrumble.common.util;
+
+import java.util.Map;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+
+import lombok.experimental.UtilityClass;
+
+/**
+ * json 타입의 String을 json object로 변환한다.
+ * NotificationMessage의 placeholder와 json object의 key 값을 매칭하여 치환한다.
+ *
+ * ex)
+ * json    : {"userName":"테스트 유저","squadName":"스크럼블"}
+ * message : {userName}님이 {squadName} 스쿼드에 참여하였습니다
+ * result  : 테스트 유저님이 스크럼블 스쿼드에 참여하였습니다
+ */
+@UtilityClass
+public class JsonToNotificationMessageConverter {
+
+	private JsonObject stringJsonDataToJson(String jsonData){
+		return new Gson().fromJson(jsonData, JsonObject.class);
+	}
+
+	// json 타입을 HashMap으로 변환하여 message의 placeholder와 치환한다.
+	public String jsonToNotificationMessage(String message, String jsonData){
+		JsonObject jsonObject = stringJsonDataToJson(jsonData);
+		StringBuilder sb = new StringBuilder(message);
+
+		for (Map.Entry<String, JsonElement> entry : jsonObject.entrySet()) {
+			String placeholder = "{" + entry.getKey() + "}";
+			int index = sb.indexOf(placeholder);
+
+			String value = entry.getValue().getAsString();
+			while(index != -1){
+				sb.replace(index, index + placeholder.length(), value);
+				index = sb.indexOf(placeholder, index + value.length());
+			}
+		}
+		return sb.toString();
+	}
+}

--- a/src/main/java/com/eggmeonina/scrumble/domain/notification/controller/NotificationController.java
+++ b/src/main/java/com/eggmeonina/scrumble/domain/notification/controller/NotificationController.java
@@ -1,0 +1,36 @@
+package com.eggmeonina.scrumble.domain.notification.controller;
+
+import java.util.List;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.eggmeonina.scrumble.common.anotation.Member;
+import com.eggmeonina.scrumble.common.domain.ApiResponse;
+import com.eggmeonina.scrumble.domain.auth.dto.LoginMember;
+import com.eggmeonina.scrumble.domain.notification.dto.NotificationResponse;
+import com.eggmeonina.scrumble.domain.notification.dto.NotificationsRequest;
+import com.eggmeonina.scrumble.domain.notification.service.NotificationService;
+
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+@Tag(name = "Notification 테스트", description = "notification용 API Controller")
+@RequestMapping("/api/notifications")
+@RestController
+@RequiredArgsConstructor
+public class NotificationController {
+
+	private final NotificationService notificationService;
+
+	@GetMapping("/me")
+	public ApiResponse<List<NotificationResponse>> findNotifications(
+		@Parameter(hidden = true) @Member LoginMember member,
+		@RequestBody NotificationsRequest notificationsRequest
+	){
+		return ApiResponse.createSuccessResponse(HttpStatus.OK.value(), notificationService.findNotifications(member.getMemberId(), notificationsRequest));
+	}
+}

--- a/src/main/java/com/eggmeonina/scrumble/domain/notification/controller/NotificationController.java
+++ b/src/main/java/com/eggmeonina/scrumble/domain/notification/controller/NotificationController.java
@@ -4,7 +4,7 @@ import java.util.List;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -29,7 +29,7 @@ public class NotificationController {
 	@GetMapping("/me")
 	public ApiResponse<List<NotificationResponse>> findNotifications(
 		@Parameter(hidden = true) @Member LoginMember member,
-		@RequestBody NotificationsRequest notificationsRequest
+		@ModelAttribute NotificationsRequest notificationsRequest
 	){
 		return ApiResponse.createSuccessResponse(HttpStatus.OK.value(), notificationService.findNotifications(member.getMemberId(), notificationsRequest));
 	}

--- a/src/main/java/com/eggmeonina/scrumble/domain/notification/domain/Notification.java
+++ b/src/main/java/com/eggmeonina/scrumble/domain/notification/domain/Notification.java
@@ -1,4 +1,4 @@
-package com.eggmeonina.scrumble.domain.todo.notification.domain;
+package com.eggmeonina.scrumble.domain.notification.domain;
 
 import static com.eggmeonina.scrumble.common.exception.ErrorCode.*;
 import static jakarta.persistence.GenerationType.*;

--- a/src/main/java/com/eggmeonina/scrumble/domain/notification/domain/NotificationMessage.java
+++ b/src/main/java/com/eggmeonina/scrumble/domain/notification/domain/NotificationMessage.java
@@ -1,0 +1,36 @@
+package com.eggmeonina.scrumble.domain.notification.domain;
+
+import static com.eggmeonina.scrumble.domain.notification.domain.NotificationType.*;
+
+import java.util.Arrays;
+
+import com.eggmeonina.scrumble.common.exception.ErrorCode;
+import com.eggmeonina.scrumble.common.exception.ExpectedException;
+import com.eggmeonina.scrumble.common.util.JsonToNotificationMessageConverter;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum NotificationMessage {
+
+	INVITE_REQUEST_MESSAGE(INVITE_REQUEST, "{userName}님이 {squadName} 스쿼드에 초대하였습니다"),
+	INVITE_ACCEPT_MESSAGE(INVITE_ACCEPT, "{userName}님이 {squadName} 스쿼드에 참여하였습니다");
+
+	private final NotificationType notificationType;
+	private final String message;
+
+	public static String getNotificationMessage(NotificationType notificationType, String jsonData) {
+		NotificationMessage message = findNotificationMessage(notificationType);
+		return JsonToNotificationMessageConverter.jsonToNotificationMessage(message.getMessage(), jsonData);
+	}
+
+	private static NotificationMessage findNotificationMessage(NotificationType notificationType) {
+		return Arrays.stream(NotificationMessage.values())
+			.filter(notificationMessage -> notificationMessage.getNotificationType().equals(notificationType))
+			.findFirst()
+			.orElseThrow(() -> new ExpectedException(ErrorCode.NOTIFICATION_TYPE_NOT_EXISTS));
+	}
+
+}

--- a/src/main/java/com/eggmeonina/scrumble/domain/notification/domain/NotificationType.java
+++ b/src/main/java/com/eggmeonina/scrumble/domain/notification/domain/NotificationType.java
@@ -1,4 +1,4 @@
-package com.eggmeonina.scrumble.domain.todo.notification.domain;
+package com.eggmeonina.scrumble.domain.notification.domain;
 
 public enum NotificationType {
 	INVITE_REQUEST,

--- a/src/main/java/com/eggmeonina/scrumble/domain/notification/dto/NotificationResponse.java
+++ b/src/main/java/com/eggmeonina/scrumble/domain/notification/dto/NotificationResponse.java
@@ -1,0 +1,35 @@
+package com.eggmeonina.scrumble.domain.notification.dto;
+
+import java.time.LocalDateTime;
+
+import com.eggmeonina.scrumble.domain.notification.domain.Notification;
+import com.eggmeonina.scrumble.domain.notification.domain.NotificationMessage;
+import com.eggmeonina.scrumble.domain.notification.domain.NotificationType;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class NotificationResponse {
+
+	private Long notificationId;
+	private NotificationType notificationType;
+	private String notificationMessage;
+	private LocalDateTime createdAt;
+	private boolean isRead;
+	private String notificationData;
+
+	public static NotificationResponse from(Notification notification){
+		return new NotificationResponse(
+			notification.getId(),
+			notification.getNotificationType(),
+			NotificationMessage.getNotificationMessage(notification.getNotificationType(), notification.getNotificationData()),
+			notification.getCreatedAt(),
+			notification.isReadFlag(),
+			notification.getNotificationData()
+		);
+	}
+}

--- a/src/main/java/com/eggmeonina/scrumble/domain/notification/dto/NotificationsRequest.java
+++ b/src/main/java/com/eggmeonina/scrumble/domain/notification/dto/NotificationsRequest.java
@@ -2,18 +2,22 @@ package com.eggmeonina.scrumble.domain.notification.dto;
 
 import java.time.LocalDateTime;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 @Getter
-@NoArgsConstructor
+@Schema(description = "알림 조회 요청 DTO")
 @AllArgsConstructor
 public class NotificationsRequest {
 
+	@Schema(description = "시작일시")
 	private LocalDateTime startDateTime;
+	@Schema(description = "종료일시")
 	private LocalDateTime endDateTime;
+	@Schema(description = "마지막 알림 Id")
 	private Long lastNotificationId;
+	@Schema(description = "페이징 사이즈")
 	private int pageSize;
 
 }

--- a/src/main/java/com/eggmeonina/scrumble/domain/notification/dto/NotificationsRequest.java
+++ b/src/main/java/com/eggmeonina/scrumble/domain/notification/dto/NotificationsRequest.java
@@ -1,0 +1,19 @@
+package com.eggmeonina.scrumble.domain.notification.dto;
+
+import java.time.LocalDateTime;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class NotificationsRequest {
+
+	private LocalDateTime startDateTime;
+	private LocalDateTime endDateTime;
+	private Long lastNotificationId;
+	private int pageSize;
+
+}

--- a/src/main/java/com/eggmeonina/scrumble/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/eggmeonina/scrumble/domain/notification/repository/NotificationRepository.java
@@ -1,0 +1,14 @@
+package com.eggmeonina.scrumble.domain.notification.repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.springframework.data.domain.Limit;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.eggmeonina.scrumble.domain.notification.domain.Notification;
+
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+
+	List<Notification> findAllByRecipientIdAndIdLessThanAndCreatedAtBetweenOrderByIdDesc(Long recipientId, Long id, LocalDateTime startDate, LocalDateTime endDate, Limit limit);
+}

--- a/src/main/java/com/eggmeonina/scrumble/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/eggmeonina/scrumble/domain/notification/service/NotificationService.java
@@ -1,0 +1,39 @@
+package com.eggmeonina.scrumble.domain.notification.service;
+
+import java.util.List;
+
+import org.springframework.data.domain.Limit;
+import org.springframework.stereotype.Service;
+
+import com.eggmeonina.scrumble.domain.notification.domain.Notification;
+import com.eggmeonina.scrumble.domain.notification.domain.NotificationType;
+import com.eggmeonina.scrumble.domain.notification.dto.NotificationsRequest;
+import com.eggmeonina.scrumble.domain.notification.dto.NotificationResponse;
+import com.eggmeonina.scrumble.domain.notification.repository.NotificationRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class NotificationService {
+	private final NotificationRepository notificationRepository;
+
+	public Long createNotification(Long memberId, NotificationType notificationType) {
+		return null;
+	}
+
+	public List<NotificationResponse> findNotifications(Long memberId, NotificationsRequest request) {
+		List<Notification> notifications
+			= notificationRepository.findAllByRecipientIdAndIdLessThanAndCreatedAtBetweenOrderByIdDesc
+			(
+				memberId,
+				request.getLastNotificationId(),
+				request.getStartDateTime(),
+				request.getEndDateTime(),
+				Limit.of(request.getPageSize())
+			);
+		return notifications.stream()
+			.map(NotificationResponse::from)
+			.toList();
+	}
+}

--- a/src/main/resources/db/h2/data.sql
+++ b/src/main/resources/db/h2/data.sql
@@ -42,6 +42,6 @@ insert into squad_todo(squad_todo_id, todo_id, squad_id, deleted_flag, created_a
 values (default, 6, 1, 0, now());
 
 insert into notification(notification_id, recipient_id, notification_type, read_flag, notification_data, created_at, updated_at)
-values (default, 2, 'INVITE_REQUEST', true, null, now(), null);
+values (default, 2, 'INVITE_REQUEST', true, '{"userName": "testA", "squadName": "테스트 스쿼드", "squadId": "1"}', now(), null);
 insert into notification(notification_id, recipient_id, notification_type, read_flag, notification_data, created_at, updated_at)
-values (default, 1, 'INVITE_ACCEPT', true, null, now(), null);
+values (default, 1, 'INVITE_ACCEPT', true, '{"userName": "scrumble", "squadName": "테스트 스쿼드"}', now(), null);

--- a/src/main/resources/db/mysql/data.sql
+++ b/src/main/resources/db/mysql/data.sql
@@ -24,6 +24,6 @@ insert into squad_todo(squad_todo_id, todo_id, squad_id, deleted_flag, created_a
 values (default, 3, 1, 0, now());
 
 insert into notification(notification_id, recipient_id, notification_type, read_flag, notification_data, created_at, updated_at)
-values (default, 2, 'INVITE_REQUEST', true, null, now(), null);
+values (default, 2, 'INVITE_REQUEST', true, '{"userName": "testA", "squadName": "테스트 스쿼드", "squadId": "1"}', now(), null);
 insert into notification(notification_id, recipient_id, notification_type, read_flag, notification_data, created_at, updated_at)
-values (default, 1, 'INVITE_ACCEPT', true, null, now(), null);
+values (default, 1, 'INVITE_ACCEPT', true, '{"userName": "scrumble", "squadName": "테스트 스쿼드"}', now(), null);

--- a/src/test/java/com/eggmeonina/scrumble/common/util/JsonToNotificationMessageConverterTest.java
+++ b/src/test/java/com/eggmeonina/scrumble/common/util/JsonToNotificationMessageConverterTest.java
@@ -1,0 +1,25 @@
+package com.eggmeonina.scrumble.common.util;
+
+import static com.eggmeonina.scrumble.common.util.JsonToNotificationMessageConverter.*;
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class JsonToNotificationMessageConverterTest {
+
+	@Test
+	@DisplayName("메세지 변환 테스트")
+	void test() {
+		// given
+		String jsonData = "{\"message1\": \"데이터\", \"message2\": \"두번째 데이터\"}";
+		String message = "새로운 {message1}, 다음 {message2}";
+
+		// when
+		String actual = jsonToNotificationMessage(message, jsonData);
+
+		// then
+		assertThat(actual).isEqualTo("새로운 데이터, 다음 두번째 데이터");
+	}
+
+}

--- a/src/test/java/com/eggmeonina/scrumble/domain/notification/domain/NotificationMessageTest.java
+++ b/src/test/java/com/eggmeonina/scrumble/domain/notification/domain/NotificationMessageTest.java
@@ -1,0 +1,45 @@
+package com.eggmeonina.scrumble.domain.notification.domain;
+
+import static com.eggmeonina.scrumble.common.util.JsonToNotificationMessageConverter.*;
+import static com.eggmeonina.scrumble.domain.notification.domain.NotificationMessage.*;
+import static com.eggmeonina.scrumble.domain.notification.domain.NotificationType.*;
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.google.gson.JsonObject;
+
+class NotificationMessageTest {
+
+	@Test
+	@DisplayName("초대 요청 메세지를 가져온다_성공")
+	void getInviteRequestMessage_success() {
+		// given
+		JsonObject json = new JsonObject();
+		json.addProperty("userName", "테스트 유저");
+		json.addProperty("squadName", "테스트 스쿼드");
+
+		// when
+		String message = getNotificationMessage(INVITE_REQUEST, json.toString());
+
+		// then
+		assertThat(message).isEqualTo(jsonToNotificationMessage(INVITE_REQUEST_MESSAGE.getMessage(), json.toString()));
+	}
+
+	@Test
+	@DisplayName("초대 수락 메세지를 가져온다_성공")
+	void getInviteAcceptMessage_success2() {
+		// given
+		JsonObject json = new JsonObject();
+		json.addProperty("userName", "테스트 유저");
+		json.addProperty("squadName", "테스트 스쿼드");
+
+		// when
+		String message = getNotificationMessage(INVITE_ACCEPT, json.toString());
+
+		// then
+		assertThat(message).isEqualTo(jsonToNotificationMessage(INVITE_ACCEPT_MESSAGE.getMessage(), json.toString()));
+	}
+
+}

--- a/src/test/java/com/eggmeonina/scrumble/domain/notification/domain/NotificationTest.java
+++ b/src/test/java/com/eggmeonina/scrumble/domain/notification/domain/NotificationTest.java
@@ -1,7 +1,7 @@
-package com.eggmeonina.scrumble.domain.todo.notification.domain;
+package com.eggmeonina.scrumble.domain.notification.domain;
 
 import static com.eggmeonina.scrumble.common.exception.ErrorCode.*;
-import static com.eggmeonina.scrumble.domain.todo.notification.domain.NotificationType.*;
+import static com.eggmeonina.scrumble.domain.notification.domain.NotificationType.*;
 import static com.eggmeonina.scrumble.fixture.NotificationFixture.*;
 import static org.assertj.core.api.Assertions.*;
 

--- a/src/test/java/com/eggmeonina/scrumble/domain/notification/service/NotificationServiceIntegrationTest.java
+++ b/src/test/java/com/eggmeonina/scrumble/domain/notification/service/NotificationServiceIntegrationTest.java
@@ -45,7 +45,7 @@ class NotificationServiceIntegrationTest extends IntegrationTestHelper {
 			new NotificationsRequest(LocalDateTime.now().minusDays(7), LocalDateTime.now(), 9999L, 10);
 
 		// when
-		List<NotificationResponse> notifications = notificationService.findNotifications(1L, request);
+		List<NotificationResponse> notifications = notificationService.findNotifications(newMember.getId(), request);
 
 		// then
 		NotificationResponse result = notifications.get(0);
@@ -74,7 +74,7 @@ class NotificationServiceIntegrationTest extends IntegrationTestHelper {
 				new NotificationsRequest(LocalDateTime.now().minusDays(7), LocalDateTime.now(), 9999L, 3);
 
 			// when
-			List<NotificationResponse> notifications = notificationService.findNotifications(1L, request);
+			List<NotificationResponse> notifications = notificationService.findNotifications(newMember.getId(), request);
 
 			// then
 			assertThat(notifications).hasSize(1);
@@ -98,7 +98,7 @@ class NotificationServiceIntegrationTest extends IntegrationTestHelper {
 				new NotificationsRequest(LocalDateTime.now().minusDays(7), LocalDateTime.now(), 9999L, pageSize);
 
 			// when
-			List<NotificationResponse> notifications = notificationService.findNotifications(1L, request);
+			List<NotificationResponse> notifications = notificationService.findNotifications(newMember.getId(), request);
 
 			// then
 			assertThat(notifications).hasSize(pageSize);

--- a/src/test/java/com/eggmeonina/scrumble/domain/notification/service/NotificationServiceIntegrationTest.java
+++ b/src/test/java/com/eggmeonina/scrumble/domain/notification/service/NotificationServiceIntegrationTest.java
@@ -1,0 +1,109 @@
+package com.eggmeonina.scrumble.domain.notification.service;
+
+import static com.eggmeonina.scrumble.fixture.NotificationFixture.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.SoftAssertions.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import com.eggmeonina.scrumble.domain.member.domain.Member;
+import com.eggmeonina.scrumble.domain.member.domain.MemberStatus;
+import com.eggmeonina.scrumble.domain.member.repository.MemberRepository;
+import com.eggmeonina.scrumble.domain.notification.domain.Notification;
+import com.eggmeonina.scrumble.domain.notification.domain.NotificationType;
+import com.eggmeonina.scrumble.domain.notification.dto.NotificationResponse;
+import com.eggmeonina.scrumble.domain.notification.dto.NotificationsRequest;
+import com.eggmeonina.scrumble.domain.notification.repository.NotificationRepository;
+import com.eggmeonina.scrumble.helper.IntegrationTestHelper;
+
+class NotificationServiceIntegrationTest extends IntegrationTestHelper {
+
+	@Autowired
+	private NotificationService notificationService;
+	@Autowired
+	private MemberRepository memberRepository;
+	@Autowired
+	private NotificationRepository notificationRepository;
+
+	@Test
+	@DisplayName("알림 리스트를 조회한다_성공")
+	void findNotifications_success() {
+		// given
+		Member newMember = createMember("test@test.com", "테스트유저", MemberStatus.JOIN);
+		Notification notification = createNotification(newMember, NotificationType.INVITE_REQUEST, false);
+
+		memberRepository.save(newMember);
+		notificationRepository.save(notification);
+
+		NotificationsRequest request =
+			new NotificationsRequest(LocalDateTime.now().minusDays(7), LocalDateTime.now(), 9999L, 10);
+
+		// when
+		List<NotificationResponse> notifications = notificationService.findNotifications(1L, request);
+
+		// then
+		NotificationResponse result = notifications.get(0);
+		assertSoftly(softly -> {
+			softly.assertThat(notifications).hasSize(1);
+			softly.assertThat(result.getNotificationId()).isEqualTo(notification.getId());
+			softly.assertThat(result.getNotificationData()).isEqualTo(notification.getNotificationData());
+			softly.assertThat(result.getNotificationType()).isEqualTo(notification.getNotificationType());
+		});
+	}
+
+	@Nested
+	@DisplayName("페이징 테스트")
+	class NotificationPagingTest {
+		@Test
+		@DisplayName("pageSize보다 데이터가 적을 때, 저장된 개수만큼 조회한다_성공")
+		void findNotificationsWhenLessThanPageSize_success() {
+			// given
+			Member newMember = createMember("test@test.com", "테스트유저", MemberStatus.JOIN);
+			Notification notification = createNotification(newMember, NotificationType.INVITE_REQUEST, false);
+
+			memberRepository.save(newMember);
+			notificationRepository.save(notification);
+
+			NotificationsRequest request =
+				new NotificationsRequest(LocalDateTime.now().minusDays(7), LocalDateTime.now(), 9999L, 3);
+
+			// when
+			List<NotificationResponse> notifications = notificationService.findNotifications(1L, request);
+
+			// then
+			assertThat(notifications).hasSize(1);
+		}
+
+		@Test
+		@DisplayName("pageSize보다 데이터가 많을 때, pageSize만큼 조회한다_성공")
+		void findNotificationsWhenMoreThanPageSize_success() {
+			// given
+			Member newMember = createMember("test@test.com", "테스트유저", MemberStatus.JOIN);
+			Notification notification1 = createNotification(newMember, NotificationType.INVITE_REQUEST, false);
+			Notification notification2 = createNotification(newMember, NotificationType.INVITE_REQUEST, false);
+			Notification notification3 = createNotification(newMember, NotificationType.INVITE_REQUEST, false);
+			Notification notification4 = createNotification(newMember, NotificationType.INVITE_ACCEPT, false);
+
+			memberRepository.save(newMember);
+			notificationRepository.saveAll(List.of(notification1, notification2, notification3, notification4));
+
+			int pageSize = 3;
+			NotificationsRequest request =
+				new NotificationsRequest(LocalDateTime.now().minusDays(7), LocalDateTime.now(), 9999L, pageSize);
+
+			// when
+			List<NotificationResponse> notifications = notificationService.findNotifications(1L, request);
+
+			// then
+			assertThat(notifications).hasSize(pageSize);
+		}
+
+	}
+
+}

--- a/src/test/java/com/eggmeonina/scrumble/fixture/NotificationFixture.java
+++ b/src/test/java/com/eggmeonina/scrumble/fixture/NotificationFixture.java
@@ -1,29 +1,40 @@
 package com.eggmeonina.scrumble.fixture;
 
+import static com.eggmeonina.scrumble.domain.notification.domain.NotificationType.*;
+
 import java.time.LocalDateTime;
 
 import com.eggmeonina.scrumble.domain.auth.domain.OauthType;
 import com.eggmeonina.scrumble.domain.member.domain.Member;
 import com.eggmeonina.scrumble.domain.member.domain.MemberStatus;
 import com.eggmeonina.scrumble.domain.member.domain.OauthInformation;
-import com.eggmeonina.scrumble.domain.todo.notification.domain.Notification;
-import com.eggmeonina.scrumble.domain.todo.notification.domain.NotificationType;
+import com.eggmeonina.scrumble.domain.notification.domain.Notification;
+import com.eggmeonina.scrumble.domain.notification.domain.NotificationType;
+import com.google.gson.JsonObject;
 
 public class NotificationFixture {
 
 	public static Notification createNotification(Member newMember, NotificationType notificationType,
 		boolean readFlag) {
+		JsonObject jsonObject = new JsonObject();
+		jsonObject.addProperty("userName", newMember.getName());
+		jsonObject.addProperty("squadName", "테스트 스쿼드");
+
+		if(notificationType.equals(INVITE_REQUEST)){
+			jsonObject.addProperty("squadId", 1L);
+		}
+
 		return Notification.create()
 			.recipient(newMember)
+			.notificationData(jsonObject.toString())
 			.notificationType(notificationType)
-			.readFlag(readFlag)
-			.build();
+			.readFlag(readFlag).build();
 	}
 
-	public static Member createMember(String email, String test, MemberStatus memberStatus) {
+	public static Member createMember(String email, String name, MemberStatus memberStatus) {
 		return Member.create()
 			.email(email)
-			.name(test)
+			.name(name)
 			.memberStatus(memberStatus)
 			.joinedAt(LocalDateTime.now())
 			.oauthInformation(new OauthInformation("1232345", OauthType.GOOGLE))


### PR DESCRIPTION
## 관련 이슈
#166 

## 작업 사항
<!-- 가장 대표적인 작업 내용 -->
현재 로그인한 회원의 Notification 목록을 조회합니다.

### 추가 정보
<!-- 이 PR에 대한 추가적인 정보가 필요하다면 작성해주세요. -->
- 알림 id, 알림 타입, 메세지, 일자, 읽음 여부, 데이터를 전달
- 읽음/안읽음 알림도 모두 조회
- n일까지만 조회, 페이징 처리 필요