### PR TITLE
Feat: ArgumentResolver 인증 객체 DB 연동하도록 변경

### DIFF
--- a/src/main/java/com/eggmeonina/scrumble/common/anotation/LoginMember.java
+++ b/src/main/java/com/eggmeonina/scrumble/common/anotation/LoginMember.java
@@ -7,5 +7,5 @@ import java.lang.annotation.Target;
 
 @Target(ElementType.PARAMETER) //타겟은 파라미터 레벨
 @Retention(RetentionPolicy.RUNTIME)
-public @interface Member {
+public @interface LoginMember {
 }

--- a/src/main/java/com/eggmeonina/scrumble/common/config/WebConfig.java
+++ b/src/main/java/com/eggmeonina/scrumble/common/config/WebConfig.java
@@ -2,16 +2,21 @@ package com.eggmeonina.scrumble.common.config;
 
 import java.util.List;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 import com.eggmeonina.scrumble.common.resolver.MemberArgumentResolver;
+import com.eggmeonina.scrumble.domain.member.repository.MemberRepository;
 
 @Configuration
 public class WebConfig implements WebMvcConfigurer {
+
+	@Autowired
+	private MemberRepository memberRepository;
 	@Override
 	public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
-		resolvers.add(new MemberArgumentResolver());
+		resolvers.add(new MemberArgumentResolver(memberRepository));
 	}
 }

--- a/src/main/java/com/eggmeonina/scrumble/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/eggmeonina/scrumble/domain/auth/controller/AuthController.java
@@ -20,7 +20,7 @@ import com.eggmeonina.scrumble.domain.auth.controller.generator.OauthGenerator;
 import com.eggmeonina.scrumble.domain.auth.domain.OauthType;
 import com.eggmeonina.scrumble.domain.auth.dto.LoginResponse;
 import com.eggmeonina.scrumble.domain.auth.dto.OauthRequest;
-import com.eggmeonina.scrumble.domain.auth.dto.LoginMember;
+import com.eggmeonina.scrumble.domain.auth.dto.MemberInfo;
 import com.eggmeonina.scrumble.domain.auth.facade.AuthFacadeService;
 import com.eggmeonina.scrumble.domain.member.domain.SessionKey;
 
@@ -65,7 +65,7 @@ public class AuthController {
 	public ApiResponse<LoginResponse> login(
 		HttpServletRequest servletRequest, @RequestBody OauthRequest request
 	) {
-		LoginMember loginMember = authFacadeService.getToken(request);
+		MemberInfo loginMember = authFacadeService.getToken(request);
 		HttpSession session = servletRequest.getSession(true);
 		session.setAttribute(SessionKey.LOGIN_USER.name(), loginMember);
 		return ApiResponse.createSuccessResponse(HttpStatus.OK.value(), LoginResponse.from(loginMember));

--- a/src/main/java/com/eggmeonina/scrumble/domain/auth/dto/LoginResponse.java
+++ b/src/main/java/com/eggmeonina/scrumble/domain/auth/dto/LoginResponse.java
@@ -15,7 +15,7 @@ public class LoginResponse {
 	@Schema(description = "닉네임")
 	private String name;
 
-	public static LoginResponse from(LoginMember member){
+	public static LoginResponse from(MemberInfo member){
 		return new LoginResponse(member.getMemberId(), member.getName());
 	}
 }

--- a/src/main/java/com/eggmeonina/scrumble/domain/auth/dto/MemberInfo.java
+++ b/src/main/java/com/eggmeonina/scrumble/domain/auth/dto/MemberInfo.java
@@ -7,12 +7,12 @@ import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
-public class LoginMember {
+public class MemberInfo {
 	private Long memberId;
 	private String email;
 	private String name;
 
-	public static LoginMember from(Member member){
-		return new LoginMember(member.getId(), member.getEmail(), member.getName());
+	public static MemberInfo from(Member member){
+		return new MemberInfo(member.getId(), member.getEmail(), member.getName());
 	}
 }

--- a/src/main/java/com/eggmeonina/scrumble/domain/auth/facade/AuthFacadeService.java
+++ b/src/main/java/com/eggmeonina/scrumble/domain/auth/facade/AuthFacadeService.java
@@ -11,7 +11,7 @@ import org.springframework.stereotype.Service;
 import com.eggmeonina.scrumble.common.exception.AuthException;
 import com.eggmeonina.scrumble.domain.auth.client.AuthClient;
 import com.eggmeonina.scrumble.domain.auth.dto.GoogleAuthClientResponse;
-import com.eggmeonina.scrumble.domain.auth.dto.LoginMember;
+import com.eggmeonina.scrumble.domain.auth.dto.MemberInfo;
 import com.eggmeonina.scrumble.domain.auth.dto.OauthRequest;
 import com.eggmeonina.scrumble.domain.auth.domain.MemberInformation;
 import com.eggmeonina.scrumble.domain.member.service.MemberService;
@@ -28,7 +28,7 @@ public class AuthFacadeService {
 		this.authClients = Collections.unmodifiableMap(authClients);
 	}
 
-	public LoginMember getToken(OauthRequest request){
+	public MemberInfo getToken(OauthRequest request){
 		AuthClient authClient = authClients.get(request.getOauthType().getAuthClientName());
 		if(authClient == null){
 			throw new AuthException(TYPE_NOT_SUPPORTED);

--- a/src/main/java/com/eggmeonina/scrumble/domain/member/controller/UserController.java
+++ b/src/main/java/com/eggmeonina/scrumble/domain/member/controller/UserController.java
@@ -9,10 +9,10 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.eggmeonina.scrumble.common.anotation.Member;
+import com.eggmeonina.scrumble.common.anotation.LoginMember;
 import com.eggmeonina.scrumble.common.domain.ApiResponse;
 import com.eggmeonina.scrumble.common.exception.MemberException;
-import com.eggmeonina.scrumble.domain.auth.dto.LoginMember;
+import com.eggmeonina.scrumble.domain.member.domain.Member;
 import com.eggmeonina.scrumble.domain.member.dto.MemberInvitationResponse;
 import com.eggmeonina.scrumble.domain.member.dto.MemberResponse;
 import com.eggmeonina.scrumble.domain.member.service.MemberService;
@@ -34,19 +34,19 @@ public class UserController {
 
 	@GetMapping("/me")
 	@Operation(summary = "나의 회원 정보 조회", description = "나의 회원 정보를 조회한다.")
-	public ApiResponse<MemberResponse> findMember(@Parameter(hidden = true) @Member LoginMember member){
-		return ApiResponse.createSuccessResponse(HttpStatus.OK.value(), memberService.findMember(member.getMemberId()));
+	public ApiResponse<MemberResponse> findMember(@Parameter(hidden = true) @LoginMember Member member){
+		return ApiResponse.createSuccessResponse(HttpStatus.OK.value(), memberService.findMember(member.getId()));
 	}
 
 	@DeleteMapping
 	@Operation(summary = "회원 탈퇴", description = "회원 탈퇴 및 세션을 만료한다")
-	public ApiResponse<Void> withdrawMember(@Parameter(hidden = true) @Member LoginMember member,
+	public ApiResponse<Void> withdrawMember(@Parameter(hidden = true) @LoginMember Member member,
 		HttpServletRequest servletRequest){
 		HttpSession session = servletRequest.getSession(false);
 		if (session == null) {
 			throw new MemberException(UNAUTHORIZED_ACCESS);
 		}
-		memberService.withdraw(member.getMemberId());
+		memberService.withdraw(member.getId());
 		session.invalidate();
 		return ApiResponse.createSuccessWithNoContentResponse(HttpStatus.OK.value());
 	}

--- a/src/main/java/com/eggmeonina/scrumble/domain/member/domain/Member.java
+++ b/src/main/java/com/eggmeonina/scrumble/domain/member/domain/Member.java
@@ -61,6 +61,17 @@ public class Member extends BaseEntity {
 		this.joinedAt = joinedAt;
 	}
 
+	public Member(Long id, String email, String name, String profileImage, OauthInformation oauthInformation,
+		MemberStatus memberStatus, LocalDateTime joinedAt) {
+		this.id = id;
+		this.email = email;
+		this.name = name;
+		this.profileImage = profileImage;
+		this.oauthInformation = oauthInformation;
+		this.memberStatus = memberStatus;
+		this.joinedAt = joinedAt;
+	}
+
 	public void withdraw(){
 		if(this.memberStatus == MemberStatus.WITHDRAW){
 			throw new MemberException(MEMBER_ALREADY_WITHDRAW);

--- a/src/main/java/com/eggmeonina/scrumble/domain/member/service/MemberService.java
+++ b/src/main/java/com/eggmeonina/scrumble/domain/member/service/MemberService.java
@@ -6,9 +6,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.eggmeonina.scrumble.common.exception.MemberException;
+import com.eggmeonina.scrumble.domain.auth.dto.MemberInfo;
 import com.eggmeonina.scrumble.domain.member.domain.Member;
 import com.eggmeonina.scrumble.domain.auth.domain.OauthType;
-import com.eggmeonina.scrumble.domain.auth.dto.LoginMember;
 import com.eggmeonina.scrumble.domain.auth.domain.MemberInformation;
 import com.eggmeonina.scrumble.domain.member.dto.MemberInvitationResponse;
 import com.eggmeonina.scrumble.domain.member.dto.MemberResponse;
@@ -24,10 +24,10 @@ public class MemberService {
 	private final MemberRepository memberRepository;
 
 	@Transactional
-	public LoginMember login(MemberInformation memberInformation, OauthType oauthType){
+	public MemberInfo login(MemberInformation memberInformation, OauthType oauthType){
 		Member foundMember = memberRepository.findByOauthId(memberInformation.getOauthId())
 			.orElseGet(() -> memberRepository.save(MemberInformation.to(memberInformation, oauthType)));
-		return LoginMember.from(foundMember);
+		return MemberInfo.from(foundMember);
 	}
 
 	public MemberResponse findMember(Long memberId){

--- a/src/main/java/com/eggmeonina/scrumble/domain/notification/controller/NotificationController.java
+++ b/src/main/java/com/eggmeonina/scrumble/domain/notification/controller/NotificationController.java
@@ -8,9 +8,9 @@ import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.eggmeonina.scrumble.common.anotation.Member;
+import com.eggmeonina.scrumble.common.anotation.LoginMember;
 import com.eggmeonina.scrumble.common.domain.ApiResponse;
-import com.eggmeonina.scrumble.domain.auth.dto.LoginMember;
+import com.eggmeonina.scrumble.domain.member.domain.Member;
 import com.eggmeonina.scrumble.domain.notification.dto.NotificationResponse;
 import com.eggmeonina.scrumble.domain.notification.dto.NotificationsRequest;
 import com.eggmeonina.scrumble.domain.notification.service.NotificationService;
@@ -28,9 +28,10 @@ public class NotificationController {
 
 	@GetMapping("/me")
 	public ApiResponse<List<NotificationResponse>> findNotifications(
-		@Parameter(hidden = true) @Member LoginMember member,
+		@Parameter(hidden = true) @LoginMember Member member,
 		@ModelAttribute NotificationsRequest notificationsRequest
 	){
-		return ApiResponse.createSuccessResponse(HttpStatus.OK.value(), notificationService.findNotifications(member.getMemberId(), notificationsRequest));
+		return ApiResponse.createSuccessResponse(HttpStatus.OK.value(), notificationService.findNotifications(
+			member.getId(), notificationsRequest));
 	}
 }

--- a/src/main/java/com/eggmeonina/scrumble/domain/squadmember/controller/SquadController.java
+++ b/src/main/java/com/eggmeonina/scrumble/domain/squadmember/controller/SquadController.java
@@ -13,9 +13,9 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.eggmeonina.scrumble.common.anotation.Member;
+import com.eggmeonina.scrumble.common.anotation.LoginMember;
 import com.eggmeonina.scrumble.common.domain.ApiResponse;
-import com.eggmeonina.scrumble.domain.auth.dto.LoginMember;
+import com.eggmeonina.scrumble.domain.member.domain.Member;
 import com.eggmeonina.scrumble.domain.squadmember.dto.SquadCreateRequest;
 import com.eggmeonina.scrumble.domain.squadmember.dto.SquadDetailResponse;
 import com.eggmeonina.scrumble.domain.squadmember.dto.SquadMemberInvitationRequest;
@@ -45,38 +45,38 @@ public class SquadController {
 	@PostMapping
 	@Operation(summary = "스쿼드를 생성한다", description = "스쿼드를 생성하면서 스쿼드장을 같이 생성한다.")
 	public ApiResponse<Map<String, Long>> createSquad(
-		@Parameter(hidden = true) @Member LoginMember member,
+		@Parameter(hidden = true) @LoginMember Member member,
 		@RequestBody @Valid SquadCreateRequest request
 	) {
-		Long squadId = squadMemberFacadeService.createSquad(member.getMemberId(), request);
+		Long squadId = squadMemberFacadeService.createSquad(member.getId(), request);
 		return ApiResponse.createSuccessResponse(HttpStatus.CREATED.value(), Map.of("squadId", squadId));
 	}
 
 	@GetMapping
 	@Operation(summary = "나의 스쿼드를 조회한다", description = "내가 속해있는 스쿼드들을 조회한다.")
 	public ApiResponse<List<SquadResponse>> findSquads(
-		@Parameter(hidden = true) @Member LoginMember member
+		@Parameter(hidden = true) @LoginMember Member member
 	) {
-		return ApiResponse.createSuccessResponse(HttpStatus.OK.value(), squadMemberService.findBySquads(member.getMemberId()));
+		return ApiResponse.createSuccessResponse(HttpStatus.OK.value(), squadMemberService.findBySquads(member.getId()));
 	}
 
 	@GetMapping("/{squadId}")
 	@Operation(summary = "스쿼드를 상세 조회한다", description = "스쿼드와 속한 멤버들을 조회한다. (스쿼드에 속한 회원만 스쿼드를 조회할 수 있다.)")
 	public ApiResponse<SquadDetailResponse> findSquad(
-		@Parameter(hidden = true) @Member LoginMember member,
+		@Parameter(hidden = true) @LoginMember Member member,
 		@PathVariable Long squadId
 	){
-		return ApiResponse.createSuccessResponse(HttpStatus.OK.value(), squadService.findSquadAndMembers(member.getMemberId(), squadId));
+		return ApiResponse.createSuccessResponse(HttpStatus.OK.value(), squadService.findSquadAndMembers(member.getId(), squadId));
 	}
 
 	@PutMapping("/{squadId}")
 	@Operation(summary = "스쿼드명을 수정한다", description = "스쿼드 리더만 스쿼드명을 수정한다.")
 	public ApiResponse<Void> updateSquad(
-		@Parameter(hidden = true) @Member LoginMember member,
+		@Parameter(hidden = true) @LoginMember Member member,
 		@PathVariable Long squadId,
 		@RequestBody @Valid SquadUpdateRequest request
 	){
-		squadMemberService.updateSquad(member.getMemberId(), squadId, request);
+		squadMemberService.updateSquad(member.getId(), squadId, request);
 		return ApiResponse.createSuccessWithNoContentResponse(HttpStatus.OK.value());
 	}
 
@@ -88,21 +88,21 @@ public class SquadController {
 		@Parameter(name = "memberId", description = "새로운 리더의 ID, path variable")
 	})
 	public ApiResponse<Void> assignLeader(
-		@Member LoginMember member,
+		@LoginMember  Member member,
 		@PathVariable("squadId") Long squadId,
 		@PathVariable("memberId") Long newLeaderId
 	){
-		squadMemberService.assignLeader(squadId, member.getMemberId(), newLeaderId);
+		squadMemberService.assignLeader(squadId, member.getId(), newLeaderId);
 		return ApiResponse.createSuccessWithNoContentResponse(HttpStatus.OK.value());
 	}
 
 	@DeleteMapping("/{squadId}/members")
 	@Operation(summary = "스쿼드를 탈퇴한다", description = "스쿼드를 탈퇴한다. 단, 리더인 경우 스쿼드 멤버가 없어야 탈퇴 가능하다.")
 	public ApiResponse<Void> leaveSquad(
-		@Parameter(hidden = true) @Member LoginMember member,
+		@Parameter(hidden = true) @LoginMember Member member,
 		@PathVariable("squadId") Long squadId
 	){
-		squadMemberService.leaveSquad(squadId,member.getMemberId());
+		squadMemberService.leaveSquad(squadId, member.getId());
 		return ApiResponse.createSuccessWithNoContentResponse(HttpStatus.OK.value());
 	}
 
@@ -114,21 +114,21 @@ public class SquadController {
 	})
 	@Operation(summary = "스쿼드 멤버를 강퇴한다", description = "스쿼드 멤버를 강퇴한다. 단, 리더인 경우에만 강퇴가 가능하다.")
 	public ApiResponse<Void> kickSquadMember(
-		@Parameter(hidden = true) @Member LoginMember member,
+		@Parameter(hidden = true) @LoginMember Member member,
 		@PathVariable("squadId") Long squadId,
 		@PathVariable("memberId") Long memberId
 	){
-		squadMemberService.kickSquadMember(squadId, member.getMemberId(),memberId);
+		squadMemberService.kickSquadMember(squadId, member.getId(),memberId);
 		return ApiResponse.createSuccessWithNoContentResponse(HttpStatus.OK.value());
 	}
 
 	@DeleteMapping("/{squadId}")
 	@Operation(summary = "스쿼드를 삭제한다", description = "스쿼드를 삭제한다. 단, 리더인 경우에만 삭제가 가능하다. 삭제 시 모든 멤버는 탈퇴된다.")
 	public ApiResponse<Void> deleteSquad(
-		@Parameter(hidden = true) @Member LoginMember member,
+		@Parameter(hidden = true) @LoginMember Member member,
 		@PathVariable("squadId") Long squadId
 	){
-		squadMemberService.deleteSquad(squadId, member.getMemberId());
+		squadMemberService.deleteSquad(squadId, member.getId());
 		return ApiResponse.createSuccessWithNoContentResponse(HttpStatus.OK.value());
 	}
 
@@ -146,10 +146,10 @@ public class SquadController {
 	@Operation(summary = "스쿼드 초대를 응답한다", description = "스쿼드 초대를 수락한다.")
 	public ApiResponse<Void> inviteMember(
 		@PathVariable("squadId") Long squadId,
-		@Parameter(hidden = true) @Member LoginMember member,
+		@Parameter(hidden = true) @LoginMember Member member,
 		@RequestBody @Valid SquadMemberInvitationRequest request
 	){
-		squadMemberService.responseInvitation(squadId, member.getMemberId(), request.getResponseStatus());
+		squadMemberService.responseInvitation(squadId, member.getId(), request.getResponseStatus());
 		return ApiResponse.createSuccessWithNoContentResponse(HttpStatus.OK.value());
 	}
 }

--- a/src/main/java/com/eggmeonina/scrumble/domain/todo/controller/TodoController.java
+++ b/src/main/java/com/eggmeonina/scrumble/domain/todo/controller/TodoController.java
@@ -14,9 +14,10 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.eggmeonina.scrumble.common.anotation.Member;
+import com.eggmeonina.scrumble.common.anotation.LoginMember;
 import com.eggmeonina.scrumble.common.domain.ApiResponse;
-import com.eggmeonina.scrumble.domain.auth.dto.LoginMember;
+import com.eggmeonina.scrumble.domain.auth.dto.MemberInfo;
+import com.eggmeonina.scrumble.domain.member.domain.Member;
 import com.eggmeonina.scrumble.domain.todo.dto.SquadTodoCreateRequest;
 import com.eggmeonina.scrumble.domain.todo.dto.SquadTodoRequest;
 import com.eggmeonina.scrumble.domain.todo.dto.SquadTodoResponse;
@@ -59,11 +60,11 @@ public class TodoController {
 	@Operation(summary = "투두를 생성한다", description = "투두를 생성한다. (스쿼드에 속한 투두)")
 	public ApiResponse<ToDoCommandResponse> createToDo(
 		@Parameter(description = "스쿼드 ID") @PathVariable Long squadId,
-		@Parameter(hidden = true) @Member LoginMember member,
+		@Parameter(hidden = true) @LoginMember Member member,
 		@RequestBody SquadTodoCreateRequest request
 	) {
 		ToDoCommandResponse response
-			= squadToDoFacadeService.createToDoAndSquadToDo(squadId, member.getMemberId(), request);
+			= squadToDoFacadeService.createToDoAndSquadToDo(squadId, member.getId(), request);
 		return ApiResponse.createSuccessResponse(HttpStatus.OK.value(), response);
 	}
 
@@ -72,9 +73,9 @@ public class TodoController {
 	public ApiResponse<Map<String, Long>> deleteToDo(
 		@Parameter(description = "투두 ID") @PathVariable Long toDoId,
 		@Parameter(description = "스쿼드 ID") @PathVariable Long squadId,
-		@Parameter(hidden = true) @Member LoginMember member
+		@Parameter(hidden = true) @LoginMember MemberInfo loginMember
 	) {
-		squadToDoFacadeService.deleteToDoAndSquadToDo(squadId, toDoId, member.getMemberId());
+		squadToDoFacadeService.deleteToDoAndSquadToDo(squadId, toDoId, loginMember.getMemberId());
 		return ApiResponse.createSuccessResponse(HttpStatus.OK.value(), Map.of("toDoId", toDoId));
 	}
 
@@ -82,10 +83,10 @@ public class TodoController {
 	@Operation(summary = "투두를 수정한다", description = "본인이 작성한 투두를 수정한다.")
 	public ApiResponse<ToDoCommandResponse> updateToDo(
 		@Parameter(description = "투두 ID") @PathVariable Long toDoId,
-		@Parameter(hidden = true) @Member LoginMember member,
+		@Parameter(hidden = true) @LoginMember Member member,
 		@RequestBody ToDoUpdateRequest request
 	) {
-		ToDoCommandResponse response = toDoService.updateToDo(member.getMemberId(), toDoId, request);
+		ToDoCommandResponse response = toDoService.updateToDo(member.getId(), toDoId, request);
 		return ApiResponse.createSuccessResponse(HttpStatus.OK.value(), response);
 	}
 
@@ -93,9 +94,9 @@ public class TodoController {
 	@Operation(summary = "나의 투두들을 조회한다", description = "내가 작성한 투두들을 조회한다.")
 	public ApiResponse<List<ToDoResponse>> getToDos(
 		@Valid @ModelAttribute ToDoRequest request,
-		@Parameter(hidden = true) @Member LoginMember member
+		@Parameter(hidden = true) @LoginMember Member member
 	) {
-		List<ToDoResponse> toDos = toDoService.findToDos(member.getMemberId(), request);
+		List<ToDoResponse> toDos = toDoService.findToDos(member.getId(), request);
 		return ApiResponse.createSuccessResponse(HttpStatus.OK.value(), toDos);
 	}
 

--- a/src/test/java/com/eggmeonina/scrumble/domain/auth/facade/AuthFacadeServiceTest.java
+++ b/src/test/java/com/eggmeonina/scrumble/domain/auth/facade/AuthFacadeServiceTest.java
@@ -20,7 +20,7 @@ import com.eggmeonina.scrumble.domain.auth.client.AuthClient;
 import com.eggmeonina.scrumble.domain.auth.domain.MemberInformation;
 import com.eggmeonina.scrumble.domain.auth.domain.OauthType;
 import com.eggmeonina.scrumble.domain.auth.dto.GoogleAuthClientResponse;
-import com.eggmeonina.scrumble.domain.auth.dto.LoginMember;
+import com.eggmeonina.scrumble.domain.auth.dto.MemberInfo;
 import com.eggmeonina.scrumble.domain.auth.dto.OauthRequest;
 import com.eggmeonina.scrumble.domain.member.service.MemberService;
 
@@ -48,20 +48,20 @@ class AuthFacadeServiceTest {
 		GoogleAuthClientResponse token
 			= new GoogleAuthClientResponse("accessToken", 1000, "tokenType", "scope", "token");
 		MemberInformation information = new MemberInformation("1233245", "test@test.com", "testA", "");
-		LoginMember mockloginMember = new LoginMember(1L, information.getEmail(), information.getName());
+		MemberInfo mockloginMemberInfo = new MemberInfo(1L, information.getEmail(), information.getName());
 
 		given(authClient.getAccessToken(any(), any())).willReturn(token);
 		given(authClient.findUserProfile(any())).willReturn(information);
-		given(memberService.login(any(), any())).willReturn(mockloginMember);
+		given(memberService.login(any(), any())).willReturn(mockloginMemberInfo);
 
 		// when
-		LoginMember actualLoginMember = authFacadeService.getToken(request);
+		MemberInfo actualLoginMember = authFacadeService.getToken(request);
 
 		// then
 		assertSoftly(softly -> {
-			softly.assertThat(actualLoginMember.getMemberId()).isEqualTo(mockloginMember.getMemberId());
-			softly.assertThat(actualLoginMember.getName()).isEqualTo(mockloginMember.getName());
-			softly.assertThat(actualLoginMember.getEmail()).isEqualTo(mockloginMember.getEmail());
+			softly.assertThat(actualLoginMember.getMemberId()).isEqualTo(mockloginMemberInfo.getMemberId());
+			softly.assertThat(actualLoginMember.getName()).isEqualTo(mockloginMemberInfo.getName());
+			softly.assertThat(actualLoginMember.getEmail()).isEqualTo(mockloginMemberInfo.getEmail());
 		});
 	}
 

--- a/src/test/java/com/eggmeonina/scrumble/domain/member/service/LoginMemberServiceIntegrationTest.java
+++ b/src/test/java/com/eggmeonina/scrumble/domain/member/service/LoginMemberServiceIntegrationTest.java
@@ -4,8 +4,6 @@ import static com.eggmeonina.scrumble.common.exception.ErrorCode.*;
 import static org.assertj.core.api.Assertions.*;
 import static org.assertj.core.api.SoftAssertions.*;
 
-import java.time.LocalDateTime;
-
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -13,10 +11,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import com.eggmeonina.scrumble.common.exception.MemberException;
 import com.eggmeonina.scrumble.domain.auth.domain.MemberInformation;
 import com.eggmeonina.scrumble.domain.auth.domain.OauthType;
-import com.eggmeonina.scrumble.domain.auth.dto.LoginMember;
+import com.eggmeonina.scrumble.domain.auth.dto.MemberInfo;
 import com.eggmeonina.scrumble.domain.member.domain.Member;
 import com.eggmeonina.scrumble.domain.member.domain.MemberStatus;
-import com.eggmeonina.scrumble.domain.member.domain.OauthInformation;
 import com.eggmeonina.scrumble.domain.member.dto.MemberResponse;
 import com.eggmeonina.scrumble.domain.member.repository.MemberRepository;
 import com.eggmeonina.scrumble.helper.IntegrationTestHelper;
@@ -36,14 +33,14 @@ class MemberServiceIntegrationTest extends IntegrationTestHelper {
 		MemberInformation request = new MemberInformation("123456789", "test@naver.com", "testName", "");
 
 		// when
-		LoginMember loginMember = memberService.login(request, OauthType.GOOGLE);
+		MemberInfo memberInfo = memberService.login(request, OauthType.GOOGLE);
 
 		Member foundMember = memberRepository.findByOauthId(request.getOauthId()).get();
 
 		// then
 		assertSoftly(softly -> {
-			softly.assertThat(loginMember.getMemberId()).isEqualTo(foundMember.getId());
-			softly.assertThat(loginMember.getEmail()).isEqualTo(foundMember.getEmail());
+			softly.assertThat(memberInfo.getMemberId()).isEqualTo(foundMember.getId());
+			softly.assertThat(memberInfo.getEmail()).isEqualTo(foundMember.getEmail());
 		});
 	}
 
@@ -56,14 +53,14 @@ class MemberServiceIntegrationTest extends IntegrationTestHelper {
 		memberRepository.save(MemberInformation.to(request, OauthType.GOOGLE));
 
 		// when
-		LoginMember loginMember = memberService.login(request, OauthType.GOOGLE);
+		MemberInfo memberInfo = memberService.login(request, OauthType.GOOGLE);
 
 		Member foundMember = memberRepository.findByOauthId(request.getOauthId()).get();
 
 		// then
 		assertSoftly(softly -> {
-			softly.assertThat(loginMember.getMemberId()).isEqualTo(foundMember.getId());
-			softly.assertThat(loginMember.getEmail()).isEqualTo(foundMember.getEmail());
+			softly.assertThat(memberInfo.getMemberId()).isEqualTo(foundMember.getId());
+			softly.assertThat(memberInfo.getEmail()).isEqualTo(foundMember.getEmail());
 		});
 	}
 

--- a/src/test/java/com/eggmeonina/scrumble/fixture/NotificationFixture.java
+++ b/src/test/java/com/eggmeonina/scrumble/fixture/NotificationFixture.java
@@ -40,4 +40,10 @@ public class NotificationFixture {
 			.oauthInformation(new OauthInformation("1232345", OauthType.GOOGLE))
 			.build();
 	}
+
+	public static Member createMemberWithMemberId(Long memberId, String email, String name, MemberStatus memberStatus,
+		String oauthId){
+		return new Member(memberId, email, name, null, new OauthInformation(oauthId, OauthType.GOOGLE), memberStatus,
+			LocalDateTime.of(2024, 11, 11, 16, 6));
+	}
 }


### PR DESCRIPTION
## 관련 이슈
#186 

## 작업 사항
<!-- 가장 대표적인 작업 내용 -->
`ArgumentResolver`의 인증 객체가 비즈니스 로직에서 DB 조회하는 경우가 많습니다. 유효성 검증(탈퇴 여부) 등을 핸들러 이전에 처리할 수 있을 것 같아서 `ArgumentResolver` 내에서 DB 조회하도록 변경하였습니다.

### 추가 정보
<!-- 이 PR에 대한 추가적인 정보가 필요하다면 작성해주세요. -->
