### PR TITLE
Feat: Notification 읽기 여부 변경 기능 개발 (#168)

### DIFF
--- a/src/main/java/com/eggmeonina/scrumble/common/exception/ErrorCode.java
+++ b/src/main/java/com/eggmeonina/scrumble/common/exception/ErrorCode.java
@@ -51,7 +51,8 @@ public enum ErrorCode {
 	 * 알림
 	 */
 	NOTIFICATION_TYPE_NOT_NULL(HttpStatus.BAD_REQUEST, "알림 타입은 비어있을 수 없습니다."),
-	NOTIFICATION_TYPE_NOT_EXISTS(HttpStatus.BAD_REQUEST, "존재하지 않는 알림 타입입니다.");
+	NOTIFICATION_TYPE_NOT_EXISTS(HttpStatus.BAD_REQUEST, "존재하지 않는 알림 타입입니다."),
+	NOTIFICATION_NOT_FOUND(HttpStatus.BAD_REQUEST, "알림이 존재하지 않습니다.");
 
 	private final HttpStatus status;
 	private final String message;

--- a/src/main/java/com/eggmeonina/scrumble/domain/member/domain/Member.java
+++ b/src/main/java/com/eggmeonina/scrumble/domain/member/domain/Member.java
@@ -3,6 +3,7 @@ package com.eggmeonina.scrumble.domain.member.domain;
 import static com.eggmeonina.scrumble.common.exception.ErrorCode.*;
 
 import java.time.LocalDateTime;
+import java.util.Objects;
 
 import org.hibernate.annotations.CreationTimestamp;
 
@@ -78,5 +79,23 @@ public class Member extends BaseEntity {
 		}
 		this.memberStatus = MemberStatus.WITHDRAW;
 		this.leavedAt = LocalDateTime.now();
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o)
+			return true;
+		if (o == null || getClass() != o.getClass())
+			return false;
+		Member member = (Member)o;
+		return Objects.equals(getId(), member.getId()) && Objects.equals(getEmail(), member.getEmail())
+			&& Objects.equals(getOauthInformation(), member.getOauthInformation())
+			&& getMemberStatus() == member.getMemberStatus() && Objects.equals(getJoinedAt(),
+			member.getJoinedAt());
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(getId(), getEmail(), getOauthInformation(), getMemberStatus(), getJoinedAt());
 	}
 }

--- a/src/main/java/com/eggmeonina/scrumble/domain/member/domain/OauthInformation.java
+++ b/src/main/java/com/eggmeonina/scrumble/domain/member/domain/OauthInformation.java
@@ -1,7 +1,5 @@
 package com.eggmeonina.scrumble.domain.member.domain;
 
-import java.util.Objects;
-
 import com.eggmeonina.scrumble.domain.auth.domain.OauthType;
 
 import jakarta.persistence.Column;
@@ -29,20 +27,5 @@ public class OauthInformation {
 	public OauthInformation(final String oauthId, final OauthType oauthType) {
 		this.oauthId = oauthId;
 		this.oauthType = oauthType;
-	}
-
-	@Override
-	public boolean equals(Object o) {
-		if (this == o)
-			return true;
-		if (o == null || getClass() != o.getClass())
-			return false;
-		OauthInformation that = (OauthInformation)o;
-		return Objects.equals(getOauthId(), that.getOauthId()) && getOauthType() == that.getOauthType();
-	}
-
-	@Override
-	public int hashCode() {
-		return Objects.hash(getOauthId(), getOauthType());
 	}
 }

--- a/src/main/java/com/eggmeonina/scrumble/domain/member/domain/OauthInformation.java
+++ b/src/main/java/com/eggmeonina/scrumble/domain/member/domain/OauthInformation.java
@@ -1,5 +1,7 @@
 package com.eggmeonina.scrumble.domain.member.domain;
 
+import java.util.Objects;
+
 import com.eggmeonina.scrumble.domain.auth.domain.OauthType;
 
 import jakarta.persistence.Column;
@@ -27,5 +29,20 @@ public class OauthInformation {
 	public OauthInformation(final String oauthId, final OauthType oauthType) {
 		this.oauthId = oauthId;
 		this.oauthType = oauthType;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o)
+			return true;
+		if (o == null || getClass() != o.getClass())
+			return false;
+		OauthInformation that = (OauthInformation)o;
+		return Objects.equals(getOauthId(), that.getOauthId()) && getOauthType() == that.getOauthType();
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(getOauthId(), getOauthType());
 	}
 }

--- a/src/main/java/com/eggmeonina/scrumble/domain/notification/controller/NotificationController.java
+++ b/src/main/java/com/eggmeonina/scrumble/domain/notification/controller/NotificationController.java
@@ -5,6 +5,8 @@ import java.util.List;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -15,6 +17,7 @@ import com.eggmeonina.scrumble.domain.notification.dto.NotificationResponse;
 import com.eggmeonina.scrumble.domain.notification.dto.NotificationsRequest;
 import com.eggmeonina.scrumble.domain.notification.service.NotificationService;
 
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -27,11 +30,22 @@ public class NotificationController {
 	private final NotificationService notificationService;
 
 	@GetMapping("/me")
+	@Operation(summary = "알림 리스트 조회", description = "나의 알림 리스트를 조회한다")
 	public ApiResponse<List<NotificationResponse>> findNotifications(
 		@Parameter(hidden = true) @LoginMember Member member,
 		@ModelAttribute NotificationsRequest notificationsRequest
 	){
 		return ApiResponse.createSuccessResponse(HttpStatus.OK.value(), notificationService.findNotifications(
 			member.getId(), notificationsRequest));
+	}
+
+	@PutMapping("/{notificationId}")
+	@Operation(summary = "알림 읽기 여부 변경", description = "알림에 대한 읽기 여부를 변경한다")
+	public ApiResponse<NotificationResponse> readNotification(
+		@Parameter(hidden = true) @LoginMember Member member,
+		@PathVariable Long notificationId
+	){
+		return ApiResponse.createSuccessResponse(HttpStatus.OK.value(),
+			notificationService.readNotification(member, notificationId));
 	}
 }

--- a/src/main/java/com/eggmeonina/scrumble/domain/notification/domain/Notification.java
+++ b/src/main/java/com/eggmeonina/scrumble/domain/notification/domain/Notification.java
@@ -9,12 +9,10 @@ import com.eggmeonina.scrumble.common.exception.MemberException;
 import com.eggmeonina.scrumble.domain.member.domain.Member;
 
 import jakarta.persistence.Column;
-import jakarta.persistence.ConstraintMode;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
-import jakarta.persistence.ForeignKey;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
@@ -36,7 +34,7 @@ public class Notification extends BaseEntity {
 	private Long id;
 
 	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "recipient_id", nullable = false, foreignKey=@ForeignKey(value = ConstraintMode.NO_CONSTRAINT))
+	@JoinColumn(name = "recipient_id", nullable = false)
 	private Member recipient;
 
 	@Column(name = "notification_type", nullable = false)
@@ -72,5 +70,11 @@ public class Notification extends BaseEntity {
 
 	public void read(){
 		this.readFlag = true;
+	}
+
+	public void checkSameRecipient(Member member){
+		if(!getRecipient().equals(member)){
+			throw new ExpectedException(UNAUTHORIZED_ACCESS);
+		}
 	}
 }

--- a/src/main/java/com/eggmeonina/scrumble/domain/notification/dto/NotificationsRequest.java
+++ b/src/main/java/com/eggmeonina/scrumble/domain/notification/dto/NotificationsRequest.java
@@ -2,6 +2,8 @@ package com.eggmeonina.scrumble.domain.notification.dto;
 
 import java.time.LocalDateTime;
 
+import org.springframework.format.annotation.DateTimeFormat;
+
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -11,8 +13,10 @@ import lombok.Getter;
 @AllArgsConstructor
 public class NotificationsRequest {
 
+	@DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
 	@Schema(description = "시작일시")
 	private LocalDateTime startDateTime;
+	@DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
 	@Schema(description = "종료일시")
 	private LocalDateTime endDateTime;
 	@Schema(description = "마지막 알림 Id")

--- a/src/main/java/com/eggmeonina/scrumble/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/eggmeonina/scrumble/domain/notification/repository/NotificationRepository.java
@@ -2,13 +2,25 @@ package com.eggmeonina.scrumble.domain.notification.repository;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.domain.Limit;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import com.eggmeonina.scrumble.domain.notification.domain.Notification;
 
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
 
 	List<Notification> findAllByRecipientIdAndIdLessThanAndCreatedAtBetweenOrderByIdDesc(Long recipientId, Long id, LocalDateTime startDate, LocalDateTime endDate, Limit limit);
+
+	@Query(
+		"""
+		SELECT n
+		  FROM Notification n
+		 WHERE n.id = :notificationId
+		   AND n.readFlag = false
+		"""
+	)
+	Optional<Notification> findByIdAndReadFlagNot(Long notificationId);
 }

--- a/src/main/java/com/eggmeonina/scrumble/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/eggmeonina/scrumble/domain/notification/service/NotificationService.java
@@ -4,7 +4,11 @@ import java.util.List;
 
 import org.springframework.data.domain.Limit;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+import com.eggmeonina.scrumble.common.exception.ErrorCode;
+import com.eggmeonina.scrumble.common.exception.ExpectedException;
+import com.eggmeonina.scrumble.domain.member.domain.Member;
 import com.eggmeonina.scrumble.domain.notification.domain.Notification;
 import com.eggmeonina.scrumble.domain.notification.domain.NotificationType;
 import com.eggmeonina.scrumble.domain.notification.dto.NotificationsRequest;
@@ -20,6 +24,21 @@ public class NotificationService {
 
 	public Long createNotification(Long memberId, NotificationType notificationType) {
 		return null;
+	}
+
+	@Transactional
+	public NotificationResponse readNotification(Member member, Long notificationId){
+		// 알림 조회
+		Notification foundNotification = notificationRepository.findByIdAndReadFlagNot(notificationId)
+			.orElseThrow(() -> new ExpectedException(ErrorCode.NOTIFICATION_NOT_FOUND));
+
+		// 알림 수신인 동일 여부 검증
+		foundNotification.checkSameRecipient(member);
+
+		// 읽기 여부 변경
+		foundNotification.read();
+
+		return NotificationResponse.from(foundNotification);
 	}
 
 	public List<NotificationResponse> findNotifications(Long memberId, NotificationsRequest request) {

--- a/src/main/resources/db/h2/data.sql
+++ b/src/main/resources/db/h2/data.sql
@@ -42,6 +42,14 @@ insert into squad_todo(squad_todo_id, todo_id, squad_id, deleted_flag, created_a
 values (default, 6, 1, 0, now());
 
 insert into notification(notification_id, recipient_id, notification_type, read_flag, notification_data, created_at, updated_at)
-values (default, 2, 'INVITE_REQUEST', true, '{"userName": "testA", "squadName": "테스트 스쿼드", "squadId": "1"}', now(), null);
+values (default, 2, 'INVITE_REQUEST', false, '{"userName": "testA", "squadName": "테스트 스쿼드", "squadId": "1"}', now(), null);
 insert into notification(notification_id, recipient_id, notification_type, read_flag, notification_data, created_at, updated_at)
-values (default, 1, 'INVITE_ACCEPT', true, '{"userName": "scrumble", "squadName": "테스트 스쿼드"}', now(), null);
+values (default, 1, 'INVITE_ACCEPT', false, '{"userName": "scrumble", "squadName": "테스트 스쿼드"}', now(), null);
+insert into notification(notification_id, recipient_id, notification_type, read_flag, notification_data, created_at, updated_at)
+values (default, 1, 'INVITE_ACCEPT', false, '{"userName": "scrumble", "squadName": "테스트 스쿼드"}', now(), null);
+insert into notification(notification_id, recipient_id, notification_type, read_flag, notification_data, created_at, updated_at)
+values (default, 1, 'INVITE_ACCEPT', false, '{"userName": "scrumble", "squadName": "테스트 스쿼드"}', now(), null);
+insert into notification(notification_id, recipient_id, notification_type, read_flag, notification_data, created_at, updated_at)
+values (default, 1, 'INVITE_ACCEPT', false, '{"userName": "scrumble", "squadName": "테스트 스쿼드"}', now(), null);
+insert into notification(notification_id, recipient_id, notification_type, read_flag, notification_data, created_at, updated_at)
+values (default, 1, 'INVITE_ACCEPT', false, '{"userName": "scrumble", "squadName": "테스트 스쿼드"}', now(), null);

--- a/src/main/resources/db/h2/schema.sql
+++ b/src/main/resources/db/h2/schema.sql
@@ -1,3 +1,17 @@
+DROP TABLE IF EXISTS notification;
+
+CREATE TABLE notification
+(
+    notification_id   BIGINT      NOT NULL AUTO_INCREMENT,
+    recipient_id      BIGINT      NOT NULL,
+    notification_type VARCHAR(50) NOT NULL,
+    read_flag         TINYINT     NOT NULL,
+    notification_data CLOB        NULL,
+    created_at        TIMESTAMP   NULL,
+    updated_at        TIMESTAMP   NULL,
+    PRIMARY KEY (notification_id)
+);
+
 DROP TABLE IF EXISTS squad_member;
 
 CREATE TABLE squad_member
@@ -71,19 +85,10 @@ CREATE TABLE member
     PRIMARY KEY (member_id)
 );
 
-DROP TABLE IF EXISTS notification;
 
-CREATE TABLE notification
-(
-    notification_id   BIGINT      NOT NULL AUTO_INCREMENT,
-    recipient_id      BIGINT      NOT NULL,
-    notification_type VARCHAR(50) NOT NULL,
-    read_flag         TINYINT     NOT NULL,
-    notification_data CLOB        NULL,
-    created_at        TIMESTAMP   NULL,
-    updated_at        TIMESTAMP   NULL,
-    PRIMARY KEY (notification_id)
-);
+ALTER TABLE notification
+    ADD CONSTRAINT FK_member_TO_notification_1 FOREIGN KEY (recipient_id)
+        REFERENCES member (member_id);
 
 
 ALTER TABLE squad_member

--- a/src/main/resources/db/mysql/schema.sql
+++ b/src/main/resources/db/mysql/schema.sql
@@ -1,3 +1,17 @@
+DROP TABLE IF EXISTS notification;
+
+CREATE TABLE notification
+(
+    notification_id   BIGINT      NOT NULL AUTO_INCREMENT,
+    recipient_id      BIGINT      NOT NULL,
+    notification_type VARCHAR(50) NOT NULL,
+    read_flag         TINYINT     NOT NULL,
+    notification_data CLOB        NULL,
+    created_at        TIMESTAMP   NULL,
+    updated_at        TIMESTAMP   NULL,
+    PRIMARY KEY (notification_id)
+);
+
 DROP TABLE IF EXISTS squad_todo;
 
 CREATE TABLE squad_todo
@@ -67,19 +81,10 @@ CREATE TABLE squad
     updated_at   datetime     NULL
 );
 
-DROP TABLE IF EXISTS notification;
 
-CREATE TABLE notification
-(
-    notification_id   bigint      NOT NULL AUTO_INCREMENT PRIMARY KEY,
-    recipient_id      bigint      NOT NULL,
-    notification_type varchar(50) NOT NULL,
-    read_flag         tinyint     NOT NULL,
-    notification_data text        NULL,
-    created_at        datetime    NULL,
-    updated_at        datetime    NULL
-);
-
+ALTER TABLE notification
+    ADD CONSTRAINT FK_member_TO_notification_1 FOREIGN KEY (recipient_id)
+        REFERENCES member (member_id);
 
 ALTER TABLE squad_member
     ADD CONSTRAINT FK_member_TO_squad_member_1 FOREIGN KEY (member_id)

--- a/src/test/java/com/eggmeonina/scrumble/domain/notification/domain/NotificationTest.java
+++ b/src/test/java/com/eggmeonina/scrumble/domain/notification/domain/NotificationTest.java
@@ -20,7 +20,7 @@ class NotificationTest {
 	@DisplayName("알림을 생성한다_성공")
 	void constructor_success() {
 		// given
-		Member newMember = createMember("test@test.com", "test", MemberStatus.JOIN);
+		Member newMember = createMember("test@test.com", "test", MemberStatus.JOIN, "1232345");
 
 		// when
 		Notification newNotification = createNotification(newMember, INVITE_REQUEST, false);
@@ -47,7 +47,7 @@ class NotificationTest {
 	@DisplayName("알림 타입 없이 알림을 생성한다_실패")
 	void constructorWithoutNotificationType_success() {
 		//given
-		Member newMember = createMember("test@test.com", "test", MemberStatus.JOIN);
+		Member newMember = createMember("test@test.com", "test", MemberStatus.JOIN, "1232345");
 
 		// when
 		assertThatThrownBy(() -> Notification.create()
@@ -63,7 +63,7 @@ class NotificationTest {
 	@DisplayName("알림 읽음 처리한다_정상")
 	void read_success() {
 		// given
-		Member newMember = createMember("test@test.com", "test", MemberStatus.JOIN);
+		Member newMember = createMember("test@test.com", "test", MemberStatus.JOIN, "1232345");
 		Notification newNotification = createNotification(newMember, INVITE_REQUEST, false);
 
 		// when
@@ -73,6 +73,17 @@ class NotificationTest {
 		assertThat(newNotification.isReadFlag()).isTrue();
 	}
 
+	@Test
+	@DisplayName("다른 회원일 때 알림 수신인 동일 여부를 확인한다_실패")
+	void checkSameRecipientWhenDifferentMember_fail() {
+		Member newMember = createMember("test@test.com", "test", MemberStatus.JOIN, "1232345");
+		Member anotherMember = createMember("anohter@test.com", "test", MemberStatus.JOIN, "54321");
+		Notification newNotification = createNotification(newMember, INVITE_REQUEST, false);
 
+		// when, then
+		assertThatThrownBy(() -> newNotification.checkSameRecipient(anotherMember))
+			.isInstanceOf(ExpectedException.class)
+			.hasMessageContaining(UNAUTHORIZED_ACCESS.getMessage());
+	}
 
 }

--- a/src/test/java/com/eggmeonina/scrumble/domain/notification/service/NotificationServiceIntegrationTest.java
+++ b/src/test/java/com/eggmeonina/scrumble/domain/notification/service/NotificationServiceIntegrationTest.java
@@ -35,7 +35,7 @@ class NotificationServiceIntegrationTest extends IntegrationTestHelper {
 	@DisplayName("알림 리스트를 조회한다_성공")
 	void findNotifications_success() {
 		// given
-		Member newMember = createMember("test@test.com", "테스트유저", MemberStatus.JOIN);
+		Member newMember = createMember("test@test.com", "테스트유저", MemberStatus.JOIN, "1232345");
 		Notification notification = createNotification(newMember, NotificationType.INVITE_REQUEST, false);
 
 		memberRepository.save(newMember);
@@ -64,7 +64,7 @@ class NotificationServiceIntegrationTest extends IntegrationTestHelper {
 		@DisplayName("pageSize보다 데이터가 적을 때, 저장된 개수만큼 조회한다_성공")
 		void findNotificationsWhenLessThanPageSize_success() {
 			// given
-			Member newMember = createMember("test@test.com", "테스트유저", MemberStatus.JOIN);
+			Member newMember = createMember("test@test.com", "테스트유저", MemberStatus.JOIN, "1232345");
 			Notification notification = createNotification(newMember, NotificationType.INVITE_REQUEST, false);
 
 			memberRepository.save(newMember);
@@ -84,7 +84,7 @@ class NotificationServiceIntegrationTest extends IntegrationTestHelper {
 		@DisplayName("pageSize보다 데이터가 많을 때, pageSize만큼 조회한다_성공")
 		void findNotificationsWhenMoreThanPageSize_success() {
 			// given
-			Member newMember = createMember("test@test.com", "테스트유저", MemberStatus.JOIN);
+			Member newMember = createMember("test@test.com", "테스트유저", MemberStatus.JOIN, "1232345");
 			Notification notification1 = createNotification(newMember, NotificationType.INVITE_REQUEST, false);
 			Notification notification2 = createNotification(newMember, NotificationType.INVITE_REQUEST, false);
 			Notification notification3 = createNotification(newMember, NotificationType.INVITE_REQUEST, false);
@@ -103,6 +103,27 @@ class NotificationServiceIntegrationTest extends IntegrationTestHelper {
 			// then
 			assertThat(notifications).hasSize(pageSize);
 		}
+
+	}
+
+	@Test
+	@DisplayName("알림 읽기 여부를 변경한다_성공")
+	void readNotification_success() {
+		// given
+		Member newMember = createMember("test@test.com", "테스트유저", MemberStatus.JOIN, "1232345");
+		Member anotherMember = createMember("another@test.com", "다른테스트유저", MemberStatus.JOIN, "34543534");
+		Notification notification = createNotification(newMember, NotificationType.INVITE_REQUEST, false);
+		Notification antoherNotification = createNotification(anotherMember, NotificationType.INVITE_REQUEST, false);
+
+		memberRepository.saveAll(List.of(newMember, anotherMember));
+		notificationRepository.saveAll(List.of(notification, antoherNotification));
+
+		// when
+		notificationService.readNotification(newMember, notification.getId());
+		Notification foundNotification = notificationRepository.findById(notification.getId()).get();
+
+		// then
+		assertThat(foundNotification.isReadFlag()).isTrue();
 
 	}
 

--- a/src/test/java/com/eggmeonina/scrumble/domain/notification/service/NotificationServiceTest.java
+++ b/src/test/java/com/eggmeonina/scrumble/domain/notification/service/NotificationServiceTest.java
@@ -1,0 +1,48 @@
+package com.eggmeonina.scrumble.domain.notification.service;
+
+import static com.eggmeonina.scrumble.common.exception.ErrorCode.*;
+import static com.eggmeonina.scrumble.fixture.NotificationFixture.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.*;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.eggmeonina.scrumble.common.exception.ExpectedException;
+import com.eggmeonina.scrumble.domain.member.domain.Member;
+import com.eggmeonina.scrumble.domain.member.domain.MemberStatus;
+import com.eggmeonina.scrumble.domain.notification.repository.NotificationRepository;
+
+@ExtendWith(MockitoExtension.class)
+class NotificationServiceTest {
+
+	@InjectMocks
+	private NotificationService notificationService;
+
+	@Mock
+	private NotificationRepository notificationRepository;
+
+	@Test
+	@DisplayName("알림이 존재하지 않을 때 읽기 여부를 변경한다_실패")
+	void readNotificationWhenNotFoundNotification_fail() {
+		// given
+		Member newMember = createMember("test@test.com", "test", MemberStatus.JOIN, "123435345");
+
+		given(notificationRepository.findByIdAndReadFlagNot(anyLong()))
+			.willReturn(Optional.empty());
+
+		// when, then
+		assertThatThrownBy(() -> notificationService.readNotification(newMember, 1L))
+			.isInstanceOf(ExpectedException.class)
+			.hasMessageContaining(NOTIFICATION_NOT_FOUND.getMessage());
+
+	}
+
+}

--- a/src/test/java/com/eggmeonina/scrumble/fixture/NotificationFixture.java
+++ b/src/test/java/com/eggmeonina/scrumble/fixture/NotificationFixture.java
@@ -31,13 +31,13 @@ public class NotificationFixture {
 			.readFlag(readFlag).build();
 	}
 
-	public static Member createMember(String email, String name, MemberStatus memberStatus) {
+	public static Member createMember(String email, String name, MemberStatus memberStatus, String oauthId) {
 		return Member.create()
 			.email(email)
 			.name(name)
 			.memberStatus(memberStatus)
 			.joinedAt(LocalDateTime.now())
-			.oauthInformation(new OauthInformation("1232345", OauthType.GOOGLE))
+			.oauthInformation(new OauthInformation(oauthId, OauthType.GOOGLE))
 			.build();
 	}
 


### PR DESCRIPTION
## 관련 이슈
closed #168 

## 작업 사항
<!-- 가장 대표적인 작업 내용 -->
`Notification` 읽기 여부 변경 기능을 개발하였습니다.
본인만 읽기 여부 변경이 가능하기 때문에 수신자 일치 여부 확인을 위해 `Member`, `OauthInformation` 객체의 동등 비교 메소드를 추가하였습니다.

### 추가 정보
<!-- 이 PR에 대한 추가적인 정보가 필요하다면 작성해주세요. -->
