### PR TITLE
Chore: 스쿼드 멤버 ToDo 리스트 조회 url, 파라미터 변경

### DIFF
--- a/src/main/java/com/eggmeonina/scrumble/domain/todo/controller/SquadToDoController.java
+++ b/src/main/java/com/eggmeonina/scrumble/domain/todo/controller/SquadToDoController.java
@@ -33,15 +33,14 @@ public class SquadToDoController {
 	private final SquadToDoFacadeService squadToDoFacadeService;
 	private final SquadTodoService squadTodoService;
 
-	@GetMapping("/squads/{squadId}/members/{memberId}")
+	@GetMapping("/squad-members/{squadMemberId}")
 	@Operation(summary = "스쿼드 투두들을 조회한다", description = "스쿼드에 속한 투두들을 조회한다.")
 	public ApiResponse<List<SquadTodoResponse>> findSquadTodos(
-		@Parameter(description = "스쿼드 ID") @PathVariable Long squadId,
-		@Parameter(description = "스쿼드 멤버 ID") @PathVariable Long memberId,
+		@Parameter(description = "스쿼드멤버 ID") @PathVariable Long squadMemberId,
 		@ModelAttribute SquadTodoRequest request
 	) {
 		return ApiResponse.createSuccessResponse(HttpStatus.OK.value(),
-			squadTodoService.findSquadTodos(squadId, memberId, request));
+			squadTodoService.findSquadTodos(squadMemberId, request));
 	}
 
 	@DeleteMapping("/{toDoId}/squads/{squadId}")

--- a/src/main/java/com/eggmeonina/scrumble/domain/todo/repository/SquadTodoRepositoryCustom.java
+++ b/src/main/java/com/eggmeonina/scrumble/domain/todo/repository/SquadTodoRepositoryCustom.java
@@ -7,5 +7,5 @@ import com.eggmeonina.scrumble.domain.todo.dto.SquadTodoResponse;
 
 public interface SquadTodoRepositoryCustom {
 
-	List<SquadTodoResponse> findSquadTodos(Long squadId, Long memberId, SquadTodoRequest request);
+	List<SquadTodoResponse> findSquadTodos(Long squadMemberId, SquadTodoRequest request);
 }

--- a/src/main/java/com/eggmeonina/scrumble/domain/todo/repository/impl/SquadTodoRepositoryCustomImpl.java
+++ b/src/main/java/com/eggmeonina/scrumble/domain/todo/repository/impl/SquadTodoRepositoryCustomImpl.java
@@ -1,6 +1,6 @@
 package com.eggmeonina.scrumble.domain.todo.repository.impl;
 
-
+import static com.eggmeonina.scrumble.domain.squadmember.domain.QSquadMember.*;
 import static com.eggmeonina.scrumble.domain.todo.domain.QSquadToDo.*;
 
 import java.util.List;
@@ -21,16 +21,18 @@ public class SquadTodoRepositoryCustomImpl implements SquadTodoRepositoryCustom 
 
 	private final JPAQueryFactory query;
 
-	public List<SquadTodoResponse> findSquadTodos(Long squadId, Long memberId, SquadTodoRequest request){
+	public List<SquadTodoResponse> findSquadTodos(Long squadMemberId, SquadTodoRequest request) {
 		return query.select(
-			new QSquadTodoResponse(squadToDo.toDo.id, squadToDo.id, squadToDo.toDo.contents, squadToDo.toDo.toDoAt, squadToDo.toDo.toDoStatus)
+				new QSquadTodoResponse(squadToDo.toDo.id, squadToDo.id, squadToDo.toDo.contents, squadToDo.toDo.toDoAt,
+					squadToDo.toDo.toDoStatus)
 			)
-			.from(squadToDo)
-			.join(squadToDo.toDo)
-			.where(squadToDo.toDo.id.gt(request.getLastToDoId())
-				.and(squadToDo.squad.id.eq(squadId))
+			.from(squadMember)
+			.join(squadToDo)
+			.on(squadMember.squad.id.eq(squadToDo.squad.id)
+				.and(squadMember.member.id.eq(squadToDo.toDo.member.id)))
+			.where(squadMember.id.eq(squadMemberId)
+				.and(squadToDo.toDo.id.gt(request.getLastToDoId()))
 				.and(squadToDo.deletedFlag.eq(false))
-				.and(squadToDo.toDo.member.id.eq(memberId))
 				.and(squadToDo.toDo.toDoAt.between(request.getStartDate(), request.getEndDate()))
 				.and(squadToDo.toDo.deletedFlag.eq(false)))
 			.limit(request.getPageSize())

--- a/src/main/java/com/eggmeonina/scrumble/domain/todo/service/SquadTodoService.java
+++ b/src/main/java/com/eggmeonina/scrumble/domain/todo/service/SquadTodoService.java
@@ -29,8 +29,8 @@ public class SquadTodoService {
 	private final SquadTodoRepository squadTodoRepository;
 	private final SquadRepository squadRepository;
 
-	public List<SquadTodoResponse> findSquadTodos(Long squadId, Long memberId, SquadTodoRequest request) {
-		return squadTodoRepository.findSquadTodos(squadId, memberId, request);
+	public List<SquadTodoResponse> findSquadTodos(Long squadMemberId, SquadTodoRequest request) {
+		return squadTodoRepository.findSquadTodos(squadMemberId, request);
 	}
 
 	@Transactional

--- a/src/test/java/com/eggmeonina/scrumble/fixture/SquadMemberFixture.java
+++ b/src/test/java/com/eggmeonina/scrumble/fixture/SquadMemberFixture.java
@@ -21,6 +21,14 @@ public class SquadMemberFixture {
 			.squadMemberStatus(status)
 			.build();
 	}
+	public static SquadMember createNormalSquadMember(Member newMember, Squad squad) {
+		return SquadMember.create()
+			.member(newMember)
+			.squad(squad)
+			.squadMemberStatus(SquadMemberStatus.JOIN)
+			.squadMemberRole(SquadMemberRole.NORMAL)
+			.build();
+	}
 
 	public static Squad createSquad(String squadName) {
 		return Squad.create()


### PR DESCRIPTION
## 관련 이슈
#190 

## 작업 사항
<!-- 가장 대표적인 작업 내용 -->
스쿼드 멤버 ToDo 리스트 조회의 멤버 정보 은닉화를 위해 url을 변경하였습니다. 이에 따라 조회 리스트를 조회하는 기준도 변경되어 쿼리를 수정하게 되었습니다.

### 추가 정보
<!-- 이 PR에 대한 추가적인 정보가 필요하다면 작성해주세요. -->
