### PR TITLE
Feat: 스쿼드 멤버 초대 시 이벤트 발행

### DIFF
--- a/src/main/java/com/eggmeonina/scrumble/domain/squadmember/controller/SquadMemberController.java
+++ b/src/main/java/com/eggmeonina/scrumble/domain/squadmember/controller/SquadMemberController.java
@@ -72,9 +72,10 @@ public class SquadMemberController {
 	@Operation(summary = "스쿼드 멤버를 초대(추가)한다", description = "스쿼드 멤버를 초대(추가)한다.")
 	public ApiResponse<Void> inviteMember(
 		@PathVariable("squadId") Long squadId,
+		@Parameter(hidden = true) @LoginMember Member member,
 		@RequestBody @Valid SquadMemberInvitationRequest request
 	) {
-		squadMemberService.inviteSquadMember(request.getNewMemberId(), squadId);
+		squadMemberService.inviteSquadMember(member.getName(), request.getNewMemberId(), squadId);
 		return ApiResponse.createSuccessWithNoContentResponse(HttpStatus.OK.value());
 	}
 

--- a/src/main/java/com/eggmeonina/scrumble/domain/squadmember/service/SquadMemberService.java
+++ b/src/main/java/com/eggmeonina/scrumble/domain/squadmember/service/SquadMemberService.java
@@ -4,22 +4,25 @@ import static com.eggmeonina.scrumble.common.exception.ErrorCode.*;
 
 import java.util.List;
 
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.eggmeonina.scrumble.common.exception.MemberException;
-import com.eggmeonina.scrumble.common.exception.SquadMemberException;
 import com.eggmeonina.scrumble.common.exception.SquadException;
+import com.eggmeonina.scrumble.common.exception.SquadMemberException;
 import com.eggmeonina.scrumble.domain.member.domain.Member;
 import com.eggmeonina.scrumble.domain.member.repository.MemberRepository;
+import com.eggmeonina.scrumble.domain.notification.domain.NotificationType;
+import com.eggmeonina.scrumble.domain.squadmember.domain.Squad;
 import com.eggmeonina.scrumble.domain.squadmember.domain.SquadMember;
 import com.eggmeonina.scrumble.domain.squadmember.domain.SquadMemberRole;
 import com.eggmeonina.scrumble.domain.squadmember.domain.SquadMemberStatus;
-import com.eggmeonina.scrumble.domain.squadmember.domain.Squad;
 import com.eggmeonina.scrumble.domain.squadmember.dto.SquadResponse;
 import com.eggmeonina.scrumble.domain.squadmember.dto.SquadUpdateRequest;
-import com.eggmeonina.scrumble.domain.squadmember.repository.SquadRepository;
+import com.eggmeonina.scrumble.domain.squadmember.event.InvitedEvent;
 import com.eggmeonina.scrumble.domain.squadmember.repository.SquadMemberRepository;
+import com.eggmeonina.scrumble.domain.squadmember.repository.SquadRepository;
 
 import lombok.RequiredArgsConstructor;
 
@@ -31,9 +34,10 @@ public class SquadMemberService {
 	private final MemberRepository memberRepository;
 	private final SquadMemberRepository squadMemberRepository;
 	private final SquadRepository squadRepository;
+	private final ApplicationEventPublisher eventPublisher;
 
 	@Transactional
-	public Long createSquadMember(Long memberId, Long squadId){
+	public Long createSquadMember(Long memberId, Long squadId) {
 		Member foundMember = memberRepository.findById(memberId)
 			.orElseThrow(() -> new MemberException(MEMBER_NOT_FOUND));
 
@@ -51,8 +55,8 @@ public class SquadMemberService {
 	}
 
 	@Transactional
-	public Long inviteSquadMember(Long memberId, Long squadId){
-		Member foundMember = memberRepository.findById(memberId)
+	public Long inviteSquadMember(String memberName, Long invitedMemberId, Long squadId) {
+		Member foundMember = memberRepository.findById(invitedMemberId)
 			.orElseThrow(() -> new MemberException(MEMBER_NOT_FOUND));
 
 		Squad foundSquad = squadRepository.findById(squadId)
@@ -66,20 +70,25 @@ public class SquadMemberService {
 			.build();
 
 		// 스쿼드에 존재하는 회원이면 예외를 발생시킨다.
-		if(squadMemberRepository.existsByMemberIdAndSquadId(memberId, squadId)){
+		if (squadMemberRepository.existsByMemberIdAndSquadId(invitedMemberId, squadId)) {
 			throw new SquadMemberException(DUPLICATE_SQUADMEMBER);
 		}
 
 		squadMemberRepository.save(newSquadMember);
+
+		// 이벤트를 발행한다.
+		eventPublisher.publishEvent(
+			new InvitedEvent(foundMember.getId(), memberName, foundSquad.getId(), foundSquad.getSquadName(),
+				NotificationType.INVITE_REQUEST));
 		return newSquadMember.getId();
 	}
 
-	public List<SquadResponse> findBySquads(Long memberId){
+	public List<SquadResponse> findBySquads(Long memberId) {
 		return squadMemberRepository.findSquads(memberId);
 	}
 
 	@Transactional
-	public void updateSquad(Long memberId, Long squadId, SquadUpdateRequest request){
+	public void updateSquad(Long memberId, Long squadId, SquadUpdateRequest request) {
 		Squad foundSquad = squadRepository.findById(squadId)
 			.orElseThrow(() -> new SquadException(SQUAD_NOT_FOUND));
 		SquadMember foundSquadMember = squadMemberRepository.findByMemberIdAndSquadId(memberId, squadId)
@@ -90,7 +99,7 @@ public class SquadMemberService {
 	}
 
 	@Transactional
-	public void assignLeader(Long squadId, Long leaderId, Long newLeaderId){
+	public void assignLeader(Long squadId, Long leaderId, Long newLeaderId) {
 		SquadMember foundLeader = squadMemberRepository.findByMemberIdAndSquadId(leaderId, squadId)
 			.orElseThrow(() -> new SquadException(SQUADMEMBER_NOT_FOUND));
 		// 스쿼드 리더가 아니면 예외를 발생시킨다.
@@ -102,18 +111,18 @@ public class SquadMemberService {
 	}
 
 	@Transactional
-	public void leaveSquad(Long squadId, Long memberId){
+	public void leaveSquad(Long squadId, Long memberId) {
 		SquadMember foundSquadMember = squadMemberRepository.findByMemberIdAndSquadId(memberId, squadId)
 			.orElseThrow(() -> new SquadMemberException(SQUADMEMBER_NOT_FOUND));
 		// 스쿼드에 인원이 있는 스쿼드 리더는 위임하거나 삭제만 가능하다.
-		if(foundSquadMember.isLeader() && squadMemberRepository.existsBySquadMemberNotMemberId(squadId, memberId)){
+		if (foundSquadMember.isLeader() && squadMemberRepository.existsBySquadMemberNotMemberId(squadId, memberId)) {
 			throw new SquadMemberException(LEADER_CANNOT_LEAVE);
 		}
 		foundSquadMember.leave();
 	}
 
 	@Transactional
-	public void kickSquadMember(Long squadId, Long leaderId, Long memberId){
+	public void kickSquadMember(Long squadId, Long leaderId, Long memberId) {
 		// 리더가 권한을 가졌는지 확인한다.
 		SquadMember squadLeader = squadMemberRepository.findByMemberIdAndSquadId(leaderId, squadId)
 			.orElseThrow(() -> new SquadMemberException(SQUADMEMBER_NOT_FOUND));
@@ -127,7 +136,7 @@ public class SquadMemberService {
 	}
 
 	@Transactional
-	public void deleteSquad(Long squadId, Long leaderId){
+	public void deleteSquad(Long squadId, Long leaderId) {
 		Squad foundSquad = squadRepository.findById(squadId)
 			.orElseThrow(() -> new SquadException(SQUAD_NOT_FOUND));
 
@@ -143,23 +152,25 @@ public class SquadMemberService {
 
 	/**
 	 * 멤버 초대 응답
+	 *
 	 * @param squadId
 	 * @param memberId
 	 * @param squadMemberStatus
 	 */
 	@Transactional
-	public void responseInvitation(Long squadId, Long memberId, SquadMemberStatus squadMemberStatus){
+	public void responseInvitation(Long squadId, Long memberId, SquadMemberStatus squadMemberStatus) {
 		squadRepository.findByIdAndDeletedFlagNot(squadId)
 			.orElseThrow(() -> new SquadException(SQUAD_NOT_FOUND));
 
-		SquadMember foundSquadMember = squadMemberRepository.findByMemberIdAndSquadIdWithInvitingStatus(memberId, squadId)
+		SquadMember foundSquadMember = squadMemberRepository.findByMemberIdAndSquadIdWithInvitingStatus(memberId,
+				squadId)
 			.orElseThrow(() -> new SquadException(SQUADMEMBER_NOT_INVITED));
 
 		foundSquadMember.responseInvitation(squadMemberStatus);
 	}
 
-	private void hasAuthorization(SquadMember squadMember){
-		if(!squadMember.isLeader()){
+	private void hasAuthorization(SquadMember squadMember) {
+		if (!squadMember.isLeader()) {
 			throw new SquadMemberException(UNAUTHORIZED_ACTION);
 		}
 	}

--- a/src/test/java/com/eggmeonina/scrumble/domain/squadmember/service/SquadMemberServiceAndSquadIntegrationTest.java
+++ b/src/test/java/com/eggmeonina/scrumble/domain/squadmember/service/SquadMemberServiceAndSquadIntegrationTest.java
@@ -12,15 +12,15 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import com.eggmeonina.scrumble.common.exception.MemberException;
-import com.eggmeonina.scrumble.common.exception.SquadMemberException;
 import com.eggmeonina.scrumble.common.exception.SquadException;
+import com.eggmeonina.scrumble.common.exception.SquadMemberException;
 import com.eggmeonina.scrumble.domain.member.domain.Member;
 import com.eggmeonina.scrumble.domain.member.domain.MemberStatus;
 import com.eggmeonina.scrumble.domain.member.repository.MemberRepository;
+import com.eggmeonina.scrumble.domain.squadmember.domain.Squad;
 import com.eggmeonina.scrumble.domain.squadmember.domain.SquadMember;
 import com.eggmeonina.scrumble.domain.squadmember.domain.SquadMemberRole;
 import com.eggmeonina.scrumble.domain.squadmember.domain.SquadMemberStatus;
-import com.eggmeonina.scrumble.domain.squadmember.domain.Squad;
 import com.eggmeonina.scrumble.domain.squadmember.dto.SquadDetailResponse;
 import com.eggmeonina.scrumble.domain.squadmember.dto.SquadResponse;
 import com.eggmeonina.scrumble.domain.squadmember.repository.SquadMemberRepository;
@@ -430,7 +430,7 @@ class SquadMemberServiceAndSquadIntegrationTest extends IntegrationTestHelper {
 		squadMemberRepository.saveAll(List.of(squadLeader, squadMember1));
 
 		// when, then
-		assertThatThrownBy(()->squadMemberService.inviteSquadMember(newMember2.getId(), newSquad.getId()))
+		assertThatThrownBy(()->squadMemberService.inviteSquadMember("testMember", newMember2.getId(), newSquad.getId()))
 			.isInstanceOf(SquadMemberException.class)
 			.hasMessageContaining(DUPLICATE_SQUADMEMBER.getMessage());
 	}
@@ -452,7 +452,7 @@ class SquadMemberServiceAndSquadIntegrationTest extends IntegrationTestHelper {
 		squadMemberRepository.saveAll(List.of(squadLeader));
 
 		// when
-		Long squadMemberId = squadMemberService.inviteSquadMember(newMember2.getId(), newSquad.getId());
+		Long squadMemberId = squadMemberService.inviteSquadMember("testMember", newMember2.getId(), newSquad.getId());
 
 		SquadMember foundSquadMember = squadMemberRepository.findById(squadMemberId).get();
 

--- a/src/test/java/com/eggmeonina/scrumble/domain/squadmember/service/SquadMemberServiceTest.java
+++ b/src/test/java/com/eggmeonina/scrumble/domain/squadmember/service/SquadMemberServiceTest.java
@@ -4,7 +4,7 @@ import static com.eggmeonina.scrumble.common.exception.ErrorCode.*;
 import static com.eggmeonina.scrumble.fixture.SquadMemberFixture.*;
 import static org.assertj.core.api.Assertions.*;
 import static org.assertj.core.api.SoftAssertions.*;
-import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.*;
 
 import java.util.List;
@@ -18,15 +18,15 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.eggmeonina.scrumble.common.exception.MemberException;
-import com.eggmeonina.scrumble.common.exception.SquadMemberException;
 import com.eggmeonina.scrumble.common.exception.SquadException;
+import com.eggmeonina.scrumble.common.exception.SquadMemberException;
 import com.eggmeonina.scrumble.domain.member.domain.Member;
 import com.eggmeonina.scrumble.domain.member.domain.MemberStatus;
 import com.eggmeonina.scrumble.domain.member.repository.MemberRepository;
+import com.eggmeonina.scrumble.domain.squadmember.domain.Squad;
 import com.eggmeonina.scrumble.domain.squadmember.domain.SquadMember;
 import com.eggmeonina.scrumble.domain.squadmember.domain.SquadMemberRole;
 import com.eggmeonina.scrumble.domain.squadmember.domain.SquadMemberStatus;
-import com.eggmeonina.scrumble.domain.squadmember.domain.Squad;
 import com.eggmeonina.scrumble.domain.squadmember.dto.SquadUpdateRequest;
 import com.eggmeonina.scrumble.domain.squadmember.repository.SquadMemberRepository;
 import com.eggmeonina.scrumble.domain.squadmember.repository.SquadRepository;
@@ -438,7 +438,7 @@ class SquadMemberServiceTest {
 			.willReturn(true);
 
 		// when, then
-		assertThatThrownBy(()->squadMemberService.inviteSquadMember(1L, 1L))
+		assertThatThrownBy(()->squadMemberService.inviteSquadMember("testMember", 1L, 1L))
 			.isInstanceOf(SquadMemberException.class)
 			.hasMessageContaining(DUPLICATE_SQUADMEMBER.getMessage());
 	}
@@ -452,7 +452,7 @@ class SquadMemberServiceTest {
 		given(squadRepository.findById(anyLong())).willReturn(Optional.empty());
 
 		// when, then
-		assertThatThrownBy(()->squadMemberService.inviteSquadMember(1L, 1L))
+		assertThatThrownBy(()->squadMemberService.inviteSquadMember("testMember", 1L, 1L))
 			.isInstanceOf(SquadMemberException.class)
 			.hasMessageContaining(SQUAD_NOT_FOUND.getMessage());
 	}
@@ -464,7 +464,7 @@ class SquadMemberServiceTest {
 		given(memberRepository.findById(anyLong())).willReturn(Optional.empty());
 
 		// when, then
-		assertThatThrownBy(()->squadMemberService.inviteSquadMember(1L, 1L))
+		assertThatThrownBy(()->squadMemberService.inviteSquadMember("testMember", 1L, 1L))
 			.isInstanceOf(MemberException.class)
 			.hasMessageContaining(MEMBER_NOT_FOUND.getMessage());
 	}


### PR DESCRIPTION
## 관련 이슈
close #206 #203 

## 작업 사항
<!-- 가장 대표적인 작업 내용 -->
- 스쿼드 멤버 초대 시 이벤트를 발행하여 관심사를 분리하였습니다.
- 스쿼드 멤버 초대 시 요청자의 이름이 아닌, 초대 받는 사람의 이름으로 이벤트가 발행되어 수정하였습니다.
