### PR TITLE
Feat: preflight 요청 시 사용자 인증 로직 스킵하도록 변경

### DIFF
--- a/src/main/java/com/eggmeonina/scrumble/common/interceptor/AuthInterceptor.java
+++ b/src/main/java/com/eggmeonina/scrumble/common/interceptor/AuthInterceptor.java
@@ -1,5 +1,7 @@
 package com.eggmeonina.scrumble.common.interceptor;
 
+import static org.springframework.http.HttpMethod.*;
+
 import org.springframework.web.servlet.HandlerInterceptor;
 
 import com.eggmeonina.scrumble.common.exception.ErrorCode;
@@ -15,10 +17,11 @@ public class AuthInterceptor implements HandlerInterceptor {
 
 	@Override
 	public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
-		log.info("authorizationInterceptor start");
+		log.debug("authorizationInterceptor start");
 		HttpSession session = request.getSession(false);
-		if (session == null) {
-			log.info("미인증 사용자 요청 URI : {}", request.getRequestURI());
+		// preflight 요청은 interceptor에서 무시한다
+		if (session == null && !OPTIONS.name().equals(request.getMethod())) {
+			log.debug("미인증 사용자 요청 URI : {}", request.getRequestURI());
 			throw new ExpectedException(ErrorCode.UNAUTHORIZED_ACCESS);
 		}
 		return true;


### PR DESCRIPTION
## 관련 이슈
#228 

## 작업 사항
<!-- 가장 대표적인 작업 내용 -->
interceptor 수정하여 `OPTIONS` 메소드로 요청 시 사용자 인증 로직 스킵하였습니다.

### 추가 정보
<!-- 이 PR에 대한 추가적인 정보가 필요하다면 작성해주세요. -->
