### PR TITLE
Feat: notificationStatus 추가 및 읽기 여부 API 변경에 따른 수정 (#202, #204)

### DIFF
--- a/src/main/java/com/eggmeonina/scrumble/domain/notification/controller/NotificationController.java
+++ b/src/main/java/com/eggmeonina/scrumble/domain/notification/controller/NotificationController.java
@@ -7,6 +7,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -14,6 +15,7 @@ import com.eggmeonina.scrumble.common.anotation.LoginMember;
 import com.eggmeonina.scrumble.common.domain.ApiResponse;
 import com.eggmeonina.scrumble.domain.member.domain.Member;
 import com.eggmeonina.scrumble.domain.notification.dto.NotificationResponse;
+import com.eggmeonina.scrumble.domain.notification.dto.NotificationUpdateRequest;
 import com.eggmeonina.scrumble.domain.notification.dto.NotificationsRequest;
 import com.eggmeonina.scrumble.domain.notification.service.NotificationService;
 
@@ -40,12 +42,13 @@ public class NotificationController {
 	}
 
 	@PutMapping("/{notificationId}")
-	@Operation(summary = "알림 읽기 여부 변경", description = "알림에 대한 읽기 여부를 변경한다")
-	public ApiResponse<NotificationResponse> readNotification(
+	@Operation(summary = "알림 상태 변경", description = "알림 상태를 변경한다 (readFlag, notificationStatus)")
+	public ApiResponse<NotificationResponse> updateNotification(
 		@Parameter(hidden = true) @LoginMember Member member,
-		@PathVariable Long notificationId
+		@PathVariable Long notificationId,
+		@RequestBody NotificationUpdateRequest notificationUpdateRequest
 	){
 		return ApiResponse.createSuccessResponse(HttpStatus.OK.value(),
-			notificationService.readNotification(member, notificationId));
+			notificationService.updateNotification(member, notificationId, notificationUpdateRequest));
 	}
 }

--- a/src/main/java/com/eggmeonina/scrumble/domain/notification/domain/Notification.java
+++ b/src/main/java/com/eggmeonina/scrumble/domain/notification/domain/Notification.java
@@ -47,13 +47,18 @@ public class Notification extends BaseEntity {
 	@Column(name = "notification_data", nullable = true)
 	private String notificationData;
 
+	@Column(name ="notification_status", nullable = false)
+	@Enumerated(EnumType.STRING)
+	private NotificationStatus notificationStatus;
+
 	@Builder(builderMethodName = "create")
 	public Notification(Member recipient, NotificationType notificationType, boolean readFlag,
-		String notificationData) {
+		String notificationData, NotificationStatus notificationStatus) {
 		this.recipient = recipient;
 		this.notificationType = notificationType;
 		this.readFlag = readFlag;
 		this.notificationData = notificationData;
+		this.notificationStatus = notificationStatus;
 
 		initValid(recipient, notificationType);
 	}
@@ -76,5 +81,16 @@ public class Notification extends BaseEntity {
 		if(!getRecipient().equals(member)){
 			throw new ExpectedException(UNAUTHORIZED_ACCESS);
 		}
+	}
+
+	@Override
+	public String toString() {
+		return "Notification{" +
+			"id=" + id +
+			", notificationType=" + notificationType +
+			", readFlag=" + readFlag +
+			", notificationData='" + notificationData + '\'' +
+			", notificationStatus=" + notificationStatus +
+			'}';
 	}
 }

--- a/src/main/java/com/eggmeonina/scrumble/domain/notification/domain/Notification.java
+++ b/src/main/java/com/eggmeonina/scrumble/domain/notification/domain/Notification.java
@@ -73,8 +73,10 @@ public class Notification extends BaseEntity {
 		}
 	}
 
-	public void read(){
-		this.readFlag = true;
+	// 알림 읽기 여부와 상태를 변경한다.
+	public void updateNotification(boolean readFlag, NotificationStatus notificationStatus){
+		this.readFlag = readFlag;
+		this.notificationStatus = notificationStatus;
 	}
 
 	public void checkSameRecipient(Member member){

--- a/src/main/java/com/eggmeonina/scrumble/domain/notification/domain/NotificationStatus.java
+++ b/src/main/java/com/eggmeonina/scrumble/domain/notification/domain/NotificationStatus.java
@@ -1,0 +1,5 @@
+package com.eggmeonina.scrumble.domain.notification.domain;
+
+public enum NotificationStatus {
+	PENDING, COMPLETED
+}

--- a/src/main/java/com/eggmeonina/scrumble/domain/notification/dto/NotificationCreateRequest.java
+++ b/src/main/java/com/eggmeonina/scrumble/domain/notification/dto/NotificationCreateRequest.java
@@ -2,6 +2,7 @@ package com.eggmeonina.scrumble.domain.notification.dto;
 
 import com.eggmeonina.scrumble.domain.member.domain.Member;
 import com.eggmeonina.scrumble.domain.notification.domain.Notification;
+import com.eggmeonina.scrumble.domain.notification.domain.NotificationStatus;
 import com.eggmeonina.scrumble.domain.notification.domain.NotificationType;
 
 import lombok.AllArgsConstructor;
@@ -22,6 +23,7 @@ public class NotificationCreateRequest {
 			.notificationType(request.getNotificationType())
 			.readFlag(false)
 			.notificationData(request.getNotificationData())
+			.notificationStatus(NotificationStatus.PENDING)
 			.build();
 	}
 }

--- a/src/main/java/com/eggmeonina/scrumble/domain/notification/dto/NotificationData.java
+++ b/src/main/java/com/eggmeonina/scrumble/domain/notification/dto/NotificationData.java
@@ -1,0 +1,10 @@
+package com.eggmeonina.scrumble.domain.notification.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class NotificationData {
+	private Long squadId;
+}

--- a/src/main/java/com/eggmeonina/scrumble/domain/notification/dto/NotificationResponse.java
+++ b/src/main/java/com/eggmeonina/scrumble/domain/notification/dto/NotificationResponse.java
@@ -2,8 +2,11 @@ package com.eggmeonina.scrumble.domain.notification.dto;
 
 import java.time.LocalDateTime;
 
+import com.eggmeonina.scrumble.common.util.JsonObjectConverter;
 import com.eggmeonina.scrumble.domain.notification.domain.Notification;
+import com.eggmeonina.scrumble.domain.notification.domain.NotificationInvitedData;
 import com.eggmeonina.scrumble.domain.notification.domain.NotificationMessage;
+import com.eggmeonina.scrumble.domain.notification.domain.NotificationStatus;
 import com.eggmeonina.scrumble.domain.notification.domain.NotificationType;
 
 import lombok.AllArgsConstructor;
@@ -20,16 +23,21 @@ public class NotificationResponse {
 	private String notificationMessage;
 	private LocalDateTime createdAt;
 	private boolean isRead;
-	private String notificationData;
+	private NotificationStatus notificationStatus;
+	private NotificationData notificationData;
 
-	public static NotificationResponse from(Notification notification){
-		return new NotificationResponse(
-			notification.getId(),
-			notification.getNotificationType(),
-			NotificationMessage.getNotificationMessage(notification.getNotificationType(), notification.getNotificationData()),
-			notification.getCreatedAt(),
-			notification.isReadFlag(),
-			notification.getNotificationData()
-		);
+	public static NotificationResponse from(Notification notification) {
+		NotificationInvitedData notificationData =
+			(NotificationInvitedData)JsonObjectConverter.JsonToObject(notification.getNotificationData(), NotificationInvitedData.class);
+		return new NotificationResponse
+			(
+				notification.getId(),
+				notification.getNotificationType(),
+				NotificationMessage.getNotificationMessage(notification.getNotificationType(), notification.getNotificationData()),
+				notification.getCreatedAt(),
+				notification.isReadFlag(),
+				notification.getNotificationStatus(),
+				new NotificationData(notificationData.getSquadId())
+			);
 	}
 }

--- a/src/main/java/com/eggmeonina/scrumble/domain/notification/dto/NotificationUpdateRequest.java
+++ b/src/main/java/com/eggmeonina/scrumble/domain/notification/dto/NotificationUpdateRequest.java
@@ -1,0 +1,19 @@
+package com.eggmeonina.scrumble.domain.notification.dto;
+
+import com.eggmeonina.scrumble.domain.notification.domain.NotificationStatus;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "알림 변경 요청 객체")
+public class NotificationUpdateRequest {
+	@Schema(description = "알림 상태 - PENDING(전송), COMPLETED(완료)")
+	private NotificationStatus notificationStatus;
+	@Schema(description = "알림 읽기 여부 - true(읽음), false(읽지 않음)")
+	private boolean readFlag;
+}

--- a/src/main/java/com/eggmeonina/scrumble/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/eggmeonina/scrumble/domain/notification/service/NotificationService.java
@@ -14,6 +14,7 @@ import com.eggmeonina.scrumble.domain.notification.domain.Notification;
 import com.eggmeonina.scrumble.domain.notification.dto.NotificationCreateRequest;
 import com.eggmeonina.scrumble.domain.notification.dto.NotificationResponse;
 import com.eggmeonina.scrumble.domain.notification.dto.NotificationSubScribeRequest;
+import com.eggmeonina.scrumble.domain.notification.dto.NotificationUpdateRequest;
 import com.eggmeonina.scrumble.domain.notification.dto.NotificationsRequest;
 import com.eggmeonina.scrumble.domain.notification.repository.NotificationRepository;
 
@@ -37,7 +38,7 @@ public class NotificationService {
 	}
 
 	@Transactional
-	public NotificationResponse readNotification(Member member, Long notificationId){
+	public NotificationResponse updateNotification(Member member, Long notificationId, NotificationUpdateRequest request){
 		// 알림 조회
 		Notification foundNotification = notificationRepository.findByIdAndReadFlagNot(notificationId)
 			.orElseThrow(() -> new ExpectedException(ErrorCode.NOTIFICATION_NOT_FOUND));
@@ -46,7 +47,7 @@ public class NotificationService {
 		foundNotification.checkSameRecipient(member);
 
 		// 읽기 여부 변경
-		foundNotification.read();
+		foundNotification.updateNotification(request.isReadFlag(), request.getNotificationStatus());
 
 		return NotificationResponse.from(foundNotification);
 	}

--- a/src/main/resources/db/h2/data.sql
+++ b/src/main/resources/db/h2/data.sql
@@ -41,15 +41,9 @@ values (default, 5, 1, 0, now());
 insert into squad_todo(squad_todo_id, todo_id, squad_id, deleted_flag, created_at)
 values (default, 6, 1, 0, now());
 
-insert into notification(notification_id, recipient_id, notification_type, read_flag, notification_data, created_at, updated_at)
-values (default, 2, 'INVITE_REQUEST', false, '{"userName": "testA", "squadName": "테스트 스쿼드", "squadId": "1"}', now(), null);
-insert into notification(notification_id, recipient_id, notification_type, read_flag, notification_data, created_at, updated_at)
-values (default, 1, 'INVITE_ACCEPT', false, '{"userName": "scrumble", "squadName": "테스트 스쿼드"}', now(), null);
-insert into notification(notification_id, recipient_id, notification_type, read_flag, notification_data, created_at, updated_at)
-values (default, 1, 'INVITE_ACCEPT', false, '{"userName": "scrumble", "squadName": "테스트 스쿼드"}', now(), null);
-insert into notification(notification_id, recipient_id, notification_type, read_flag, notification_data, created_at, updated_at)
-values (default, 1, 'INVITE_ACCEPT', false, '{"userName": "scrumble", "squadName": "테스트 스쿼드"}', now(), null);
-insert into notification(notification_id, recipient_id, notification_type, read_flag, notification_data, created_at, updated_at)
-values (default, 1, 'INVITE_ACCEPT', false, '{"userName": "scrumble", "squadName": "테스트 스쿼드"}', now(), null);
-insert into notification(notification_id, recipient_id, notification_type, read_flag, notification_data, created_at, updated_at)
-values (default, 1, 'INVITE_ACCEPT', false, '{"userName": "scrumble", "squadName": "테스트 스쿼드"}', now(), null);
+insert into notification(notification_id, recipient_id, notification_type, read_flag, notification_data, notification_status, created_at, updated_at)
+values (default, 2, 'INVITE_REQUEST', false, '{"memberName": "testA", "squadName": "테스트 스쿼드", "squadId": "1"}', 'PENDING',  now(), null);
+insert into notification(notification_id, recipient_id, notification_type, read_flag, notification_data, notification_status, created_at, updated_at)
+values (default, 1, 'INVITE_REQUEST', false, '{"memberName": "scrumble", "squadName": "테스트 스쿼드1", "squadId": "2"}', 'PENDING',  now(), null);
+insert into notification(notification_id, recipient_id, notification_type, read_flag, notification_data, notification_status, created_at, updated_at)
+values (default, 1, 'INVITE_REQUEST', true, '{"memberName": "scrumble", "squadName": "테스트 스쿼드2", "squadId": "3"}', 'PENDING', now(), null);

--- a/src/main/resources/db/h2/schema.sql
+++ b/src/main/resources/db/h2/schema.sql
@@ -2,13 +2,14 @@ DROP TABLE IF EXISTS notification;
 
 CREATE TABLE notification
 (
-    notification_id   BIGINT      NOT NULL AUTO_INCREMENT,
-    recipient_id      BIGINT      NOT NULL,
-    notification_type VARCHAR(50) NOT NULL,
-    read_flag         TINYINT     NOT NULL,
-    notification_data CLOB        NULL,
-    created_at        TIMESTAMP   NULL,
-    updated_at        TIMESTAMP   NULL,
+    notification_id     BIGINT      NOT NULL AUTO_INCREMENT,
+    recipient_id        BIGINT      NOT NULL,
+    notification_type   VARCHAR(50) NOT NULL,
+    read_flag           TINYINT     NOT NULL,
+    notification_data   CLOB        NULL,
+    notification_status VARCHAR(50) NOT NULL,
+    created_at          TIMESTAMP   NULL,
+    updated_at          TIMESTAMP   NULL,
     PRIMARY KEY (notification_id)
 );
 

--- a/src/main/resources/db/mysql/data.sql
+++ b/src/main/resources/db/mysql/data.sql
@@ -23,7 +23,9 @@ values (default, 2, 1, 0, now());
 insert into squad_todo(squad_todo_id, todo_id, squad_id, deleted_flag, created_at)
 values (default, 3, 1, 0, now());
 
-insert into notification(notification_id, recipient_id, notification_type, read_flag, notification_data, created_at, updated_at)
-values (default, 2, 'INVITE_REQUEST', true, '{"userName": "testA", "squadName": "테스트 스쿼드", "squadId": "1"}', now(), null);
-insert into notification(notification_id, recipient_id, notification_type, read_flag, notification_data, created_at, updated_at)
-values (default, 1, 'INVITE_ACCEPT', true, '{"userName": "scrumble", "squadName": "테스트 스쿼드"}', now(), null);
+insert into notification(notification_id, recipient_id, notification_type, read_flag, notification_data, notification_status, created_at, updated_at)
+values (default, 2, 'INVITE_REQUEST', false, '{"memberName": "testA", "squadName": "테스트 스쿼드", "squadId": "1"}', 'PENDING',  now(), null);
+insert into notification(notification_id, recipient_id, notification_type, read_flag, notification_data, notification_status, created_at, updated_at)
+values (default, 1, 'INVITE_REQUEST', false, '{"memberName": "scrumble", "squadName": "테스트 스쿼드1", "squadId": "2"}', 'PENDING',  now(), null);
+insert into notification(notification_id, recipient_id, notification_type, read_flag, notification_data, notification_status, created_at, updated_at)
+values (default, 1, 'INVITE_REQUEST', true, '{"memberName": "scrumble", "squadName": "테스트 스쿼드2", "squadId": "3"}', 'PENDING', now(), null);

--- a/src/main/resources/db/mysql/schema.sql
+++ b/src/main/resources/db/mysql/schema.sql
@@ -2,13 +2,14 @@ DROP TABLE IF EXISTS notification;
 
 CREATE TABLE notification
 (
-    notification_id   BIGINT      NOT NULL AUTO_INCREMENT,
-    recipient_id      BIGINT      NOT NULL,
-    notification_type VARCHAR(50) NOT NULL,
-    read_flag         TINYINT     NOT NULL,
-    notification_data CLOB        NULL,
-    created_at        TIMESTAMP   NULL,
-    updated_at        TIMESTAMP   NULL,
+    notification_id     BIGINT      NOT NULL AUTO_INCREMENT,
+    recipient_id        BIGINT      NOT NULL,
+    notification_type   VARCHAR(50) NOT NULL,
+    read_flag           TINYINT     NOT NULL,
+    notification_data   CLOB        NULL,
+    notification_status VARCHAR(50) NOT NULL,
+    created_at          TIMESTAMP   NULL,
+    updated_at          TIMESTAMP   NULL,
     PRIMARY KEY (notification_id)
 );
 

--- a/src/test/java/com/eggmeonina/scrumble/domain/notification/domain/NotificationTest.java
+++ b/src/test/java/com/eggmeonina/scrumble/domain/notification/domain/NotificationTest.java
@@ -5,7 +5,6 @@ import static com.eggmeonina.scrumble.domain.notification.domain.NotificationTyp
 import static com.eggmeonina.scrumble.fixture.NotificationFixture.*;
 import static org.assertj.core.api.Assertions.*;
 
-
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -67,7 +66,7 @@ class NotificationTest {
 		Notification newNotification = createNotification(newMember, INVITE_REQUEST, false);
 
 		// when
-		newNotification.read();
+		newNotification.updateNotification(true, NotificationStatus.PENDING);
 
 		// then
 		assertThat(newNotification.isReadFlag()).isTrue();

--- a/src/test/java/com/eggmeonina/scrumble/domain/notification/service/NotificationServiceIntegrationTest.java
+++ b/src/test/java/com/eggmeonina/scrumble/domain/notification/service/NotificationServiceIntegrationTest.java
@@ -16,8 +16,10 @@ import com.eggmeonina.scrumble.domain.member.domain.Member;
 import com.eggmeonina.scrumble.domain.member.domain.MemberStatus;
 import com.eggmeonina.scrumble.domain.member.repository.MemberRepository;
 import com.eggmeonina.scrumble.domain.notification.domain.Notification;
+import com.eggmeonina.scrumble.domain.notification.domain.NotificationStatus;
 import com.eggmeonina.scrumble.domain.notification.domain.NotificationType;
 import com.eggmeonina.scrumble.domain.notification.dto.NotificationResponse;
+import com.eggmeonina.scrumble.domain.notification.dto.NotificationUpdateRequest;
 import com.eggmeonina.scrumble.domain.notification.dto.NotificationsRequest;
 import com.eggmeonina.scrumble.domain.notification.repository.NotificationRepository;
 import com.eggmeonina.scrumble.helper.IntegrationTestHelper;
@@ -52,7 +54,7 @@ class NotificationServiceIntegrationTest extends IntegrationTestHelper {
 		assertSoftly(softly -> {
 			softly.assertThat(notifications).hasSize(1);
 			softly.assertThat(result.getNotificationId()).isEqualTo(notification.getId());
-			softly.assertThat(result.getNotificationData()).isEqualTo(notification.getNotificationData());
+			softly.assertThat(result.getNotificationData().getSquadId()).isEqualTo(notification.getId());
 			softly.assertThat(result.getNotificationType()).isEqualTo(notification.getNotificationType());
 		});
 	}
@@ -114,12 +116,13 @@ class NotificationServiceIntegrationTest extends IntegrationTestHelper {
 		Member anotherMember = createMember("another@test.com", "다른테스트유저", MemberStatus.JOIN, "34543534");
 		Notification notification = createNotification(newMember, NotificationType.INVITE_REQUEST, false);
 		Notification antoherNotification = createNotification(anotherMember, NotificationType.INVITE_REQUEST, false);
+		NotificationUpdateRequest request = new NotificationUpdateRequest(NotificationStatus.PENDING, true);
 
 		memberRepository.saveAll(List.of(newMember, anotherMember));
 		notificationRepository.saveAll(List.of(notification, antoherNotification));
 
 		// when
-		notificationService.readNotification(newMember, notification.getId());
+		notificationService.updateNotification(newMember, notification.getId(), request);
 		Notification foundNotification = notificationRepository.findById(notification.getId()).get();
 
 		// then

--- a/src/test/java/com/eggmeonina/scrumble/domain/notification/service/NotificationServiceTest.java
+++ b/src/test/java/com/eggmeonina/scrumble/domain/notification/service/NotificationServiceTest.java
@@ -39,7 +39,7 @@ class NotificationServiceTest {
 			.willReturn(Optional.empty());
 
 		// when, then
-		assertThatThrownBy(() -> notificationService.readNotification(newMember, 1L))
+		assertThatThrownBy(() -> notificationService.updateNotification(newMember, 1L, any()))
 			.isInstanceOf(ExpectedException.class)
 			.hasMessageContaining(NOTIFICATION_NOT_FOUND.getMessage());
 

--- a/src/test/java/com/eggmeonina/scrumble/fixture/NotificationFixture.java
+++ b/src/test/java/com/eggmeonina/scrumble/fixture/NotificationFixture.java
@@ -9,6 +9,7 @@ import com.eggmeonina.scrumble.domain.member.domain.Member;
 import com.eggmeonina.scrumble.domain.member.domain.MemberStatus;
 import com.eggmeonina.scrumble.domain.member.domain.OauthInformation;
 import com.eggmeonina.scrumble.domain.notification.domain.Notification;
+import com.eggmeonina.scrumble.domain.notification.domain.NotificationStatus;
 import com.eggmeonina.scrumble.domain.notification.domain.NotificationType;
 import com.google.gson.JsonObject;
 
@@ -28,7 +29,9 @@ public class NotificationFixture {
 			.recipient(newMember)
 			.notificationData(jsonObject.toString())
 			.notificationType(notificationType)
-			.readFlag(readFlag).build();
+			.readFlag(readFlag)
+			.notificationStatus(NotificationStatus.PENDING)
+			.build();
 	}
 
 	public static Member createMember(String email, String name, MemberStatus memberStatus, String oauthId) {


### PR DESCRIPTION
## 관련 이슈
close #202 #204 

## 작업 사항
<!-- 가장 대표적인 작업 내용 -->
`notificationStatus` 추가에 따른 변경사항을 추가하였습니다.
- `notificationStatus` 추가
- `notification` 읽기 여부 API -> `notification` 상태 변경 API 변경
- `notification` 조회 API 응답 수정

### 추가 정보
<!-- 이 PR에 대한 추가적인 정보가 필요하다면 작성해주세요. -->
