### PR TITLE
Fix : interceptor 롤백 및 로깅 필터 미적용

### DIFF
--- a/src/main/java/com/eggmeonina/scrumble/common/config/LoggingFilter.java
+++ b/src/main/java/com/eggmeonina/scrumble/common/config/LoggingFilter.java
@@ -5,7 +5,6 @@ import java.util.Collection;
 
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
-import org.springframework.stereotype.Component;
 import org.springframework.web.util.ContentCachingRequestWrapper;
 import org.springframework.web.util.ContentCachingResponseWrapper;
 
@@ -19,7 +18,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
-@Component
+// @Component
 @Order(Ordered.HIGHEST_PRECEDENCE)
 public class LoggingFilter implements Filter {
 	@Override

--- a/src/main/java/com/eggmeonina/scrumble/common/interceptor/AuthInterceptor.java
+++ b/src/main/java/com/eggmeonina/scrumble/common/interceptor/AuthInterceptor.java
@@ -4,6 +4,9 @@ import static org.springframework.http.HttpMethod.*;
 
 import org.springframework.web.servlet.HandlerInterceptor;
 
+import com.eggmeonina.scrumble.common.exception.ErrorCode;
+import com.eggmeonina.scrumble.common.exception.ExpectedException;
+
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpSession;
@@ -19,7 +22,7 @@ public class AuthInterceptor implements HandlerInterceptor {
 		// preflight 요청은 interceptor에서 무시한다
 		if (session == null && !OPTIONS.name().equals(request.getMethod())) {
 			log.debug("미인증 사용자 요청 URI : {}", request.getRequestURI());
-			// throw new ExpectedException(ErrorCode.UNAUTHORIZED_ACCESS);
+			throw new ExpectedException(ErrorCode.UNAUTHORIZED_ACCESS);
 		}
 		return true;
 	}


### PR DESCRIPTION
## 관련 이슈
#238 

## 작업 사항
<!-- 가장 대표적인 작업 내용 -->
sse 연동 오류가 백엔드 서버 오류가 아니기 때문에
제외했던 사용자 인증 로직을 허용하고 임시 로깅 필터를 제거합니다.

### 추가 정보
<!-- 이 PR에 대한 추가적인 정보가 필요하다면 작성해주세요. -->
