### PR TITLE
Feat: 로그인 API 엔드포인트를 oauth redirect uri로 수정 (#252)

### DIFF
--- a/src/main/java/com/eggmeonina/scrumble/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/eggmeonina/scrumble/domain/auth/controller/AuthController.java
@@ -8,8 +8,8 @@ import java.util.Map;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -19,8 +19,8 @@ import com.eggmeonina.scrumble.common.exception.AuthException;
 import com.eggmeonina.scrumble.domain.auth.controller.generator.OauthGenerator;
 import com.eggmeonina.scrumble.domain.auth.domain.OauthType;
 import com.eggmeonina.scrumble.domain.auth.dto.LoginResponse;
-import com.eggmeonina.scrumble.domain.auth.dto.OauthRequest;
 import com.eggmeonina.scrumble.domain.auth.dto.MemberInfo;
+import com.eggmeonina.scrumble.domain.auth.dto.OauthRequest;
 import com.eggmeonina.scrumble.domain.auth.facade.AuthFacadeService;
 import com.eggmeonina.scrumble.domain.member.domain.SessionKey;
 
@@ -57,15 +57,18 @@ public class AuthController {
 		return ApiResponse.createSuccessResponse(HttpStatus.OK.value(), response);
 	}
 
-	@PostMapping("/login")
+	@GetMapping("/login/{oauthType}")
 	@Operation(summary = "OAuth2 authorization_code를 받아 로그인/회원가입을 한다", description = "OAuth2 Authorization Code Grant 로그인",
 		parameters = {@Parameter(name = "oauthType", description = "oauth type || GOOGLE : 구글로그인"),
 		@Parameter(name = "code", description = "oauth 서버에서 응답된 code"),
 		@Parameter(name = "scope", description = "oauth 서버에서 응답된 scope")})
 	public ApiResponse<LoginResponse> login(
-		HttpServletRequest servletRequest, @RequestBody OauthRequest request
+		@PathVariable OauthType oauthType,
+		@RequestParam String code,
+		@RequestParam String scope,
+		HttpServletRequest servletRequest
 	) {
-		MemberInfo loginMember = authFacadeService.getToken(request);
+		MemberInfo loginMember = authFacadeService.getToken(new OauthRequest(oauthType, code, scope));
 		HttpSession session = servletRequest.getSession(true);
 		session.setAttribute(SessionKey.LOGIN_USER.name(), loginMember);
 		return ApiResponse.createSuccessResponse(HttpStatus.OK.value(), LoginResponse.from(loginMember));

--- a/src/main/resources/config/application-oauth.yml
+++ b/src/main/resources/config/application-oauth.yml
@@ -8,7 +8,7 @@ oauth:
   google:
     client-id: ENC(Axm4OtN14/bqg4GErGhc6aOV4aHnKw34sReylM5W4FBgKXwTM43rBQParFh3wCOEA4unHkxprzE2mcW5aJX7IZvoyaIqJ1xpcWwdlHlmpB8/ufMtuQv1aA==)
     client-key: ENC(2ogGtYgdg6QzpB8hcch437ktFh+b/CPo3okFrqdwwE0czauMEDF34B0Xe0b4s4Y3)
-    redirect_uri: ENC(Ny4lsDu+Ik3M9NHDloSgfStvfgxUSxdQKFbEJs9eeI9tVlLsywxLV/Vb9jgvgWSkZIcHOsSvu29VoATxoPbs1g==)
+    redirect_uri: ENC(wnKnwYuY2KvPmlJieoO1/ikYdt0FZ9JNACgRdwwjFFSrGyqzZrhIbBG6LOJF0/9JZQoVqiQR4jTyw7TeYOVVmA==)
     response_type: code
     scope: profile+email
 
@@ -27,7 +27,7 @@ oauth:
   google:
     client-id: ENC(Axm4OtN14/bqg4GErGhc6aOV4aHnKw34sReylM5W4FBgKXwTM43rBQParFh3wCOEA4unHkxprzE2mcW5aJX7IZvoyaIqJ1xpcWwdlHlmpB8/ufMtuQv1aA==)
     client-key: ENC(2ogGtYgdg6QzpB8hcch437ktFh+b/CPo3okFrqdwwE0czauMEDF34B0Xe0b4s4Y3)
-    redirect_uri: ENC(MrEH5hLuu0C4p4YBSM+g4aakuW3zFjiMEO7vp9w3G19lcvyNkO9bb/b9Q5CmuhdmdpAoS7jNpdQu/+a+CmLmLw==)
+    redirect_uri: ENC(NPAfJC2neDXtn5ioCgwFz9JonHpzQzUJT7uJXeIUtjJVASYtdPG3kpTdgvWLtKMVF24rnpqRXoEkq48K1Vr3Zw==)
     response_type: code
     scope: profile+email
 
@@ -46,7 +46,7 @@ oauth:
   google:
     client-id: ENC(Axm4OtN14/bqg4GErGhc6aOV4aHnKw34sReylM5W4FBgKXwTM43rBQParFh3wCOEA4unHkxprzE2mcW5aJX7IZvoyaIqJ1xpcWwdlHlmpB8/ufMtuQv1aA==)
     client-key: ENC(2ogGtYgdg6QzpB8hcch437ktFh+b/CPo3okFrqdwwE0czauMEDF34B0Xe0b4s4Y3)
-    redirect_uri: ENC(khtmPRlQz6Wk3AjRmJJ6JR/ASR0cHRRZPZCD8yPTrPthAlk8YzgK6hpsej2473TTRG9W8RGCvek=)
+    redirect_uri: ENC(fKnCEdsQWA0XGmBmOmZePU5axEJ6azgBOI0id7Tw+jUy84DeX7nx+SQ8QEGWnwJXLkJyvAKpT4I=)
     response_type: code
     scope: profile+email
 


### PR DESCRIPTION
## 관련 이슈
#252 

## 작업 사항
<!-- 가장 대표적인 작업 내용 -->
로그인 API의 엔드포인트를 oauth redirect uri로 수정합니다.
클라이언트가 요청을 처리하려고 했지만 code나 scope가 유출될 가능성이 있기 때문에 서버에서 redirect uri 요청을 처리합니다.
별도의 핸들링을 하지 않는 이유는 제한된 시간 상에 구현해야하기 때문에 일감 추가를 지양하기 위함입니다.


### 추가 정보
<!-- 이 PR에 대한 추가적인 정보가 필요하다면 작성해주세요. -->
