### PR TITLE
Fix: 알림 변경 시 조회 조건 변경 (#260)

### DIFF
--- a/src/main/java/com/eggmeonina/scrumble/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/eggmeonina/scrumble/domain/notification/service/NotificationService.java
@@ -40,7 +40,7 @@ public class NotificationService {
 	@Transactional
 	public NotificationResponse updateNotification(Member member, Long notificationId, NotificationUpdateRequest request){
 		// 알림 조회
-		Notification foundNotification = notificationRepository.findByIdAndReadFlagNot(notificationId)
+		Notification foundNotification = notificationRepository.findById(notificationId)
 			.orElseThrow(() -> new ExpectedException(ErrorCode.NOTIFICATION_NOT_FOUND));
 
 		// 알림 수신인 동일 여부 검증

--- a/src/test/java/com/eggmeonina/scrumble/domain/notification/domain/NotificationTest.java
+++ b/src/test/java/com/eggmeonina/scrumble/domain/notification/domain/NotificationTest.java
@@ -22,7 +22,7 @@ class NotificationTest {
 		Member newMember = createMember("test@test.com", "test", MemberStatus.JOIN, "1232345");
 
 		// when
-		Notification newNotification = createNotification(newMember, INVITE_REQUEST, false);
+		Notification newNotification = createNotification(newMember, INVITE_REQUEST, false, NotificationStatus.PENDING);
 
 		// then
 		assertThat(newNotification.getNotificationType()).isEqualTo(INVITE_REQUEST);
@@ -63,7 +63,7 @@ class NotificationTest {
 	void read_success() {
 		// given
 		Member newMember = createMember("test@test.com", "test", MemberStatus.JOIN, "1232345");
-		Notification newNotification = createNotification(newMember, INVITE_REQUEST, false);
+		Notification newNotification = createNotification(newMember, INVITE_REQUEST, false, NotificationStatus.PENDING);
 
 		// when
 		newNotification.updateNotification(true, NotificationStatus.PENDING);
@@ -77,7 +77,7 @@ class NotificationTest {
 	void checkSameRecipientWhenDifferentMember_fail() {
 		Member newMember = createMember("test@test.com", "test", MemberStatus.JOIN, "1232345");
 		Member anotherMember = createMember("anohter@test.com", "test", MemberStatus.JOIN, "54321");
-		Notification newNotification = createNotification(newMember, INVITE_REQUEST, false);
+		Notification newNotification = createNotification(newMember, INVITE_REQUEST, false, NotificationStatus.PENDING);
 
 		// when, then
 		assertThatThrownBy(() -> newNotification.checkSameRecipient(anotherMember))

--- a/src/test/java/com/eggmeonina/scrumble/domain/notification/service/NotificationServiceTest.java
+++ b/src/test/java/com/eggmeonina/scrumble/domain/notification/service/NotificationServiceTest.java
@@ -35,7 +35,7 @@ class NotificationServiceTest {
 		// given
 		Member newMember = createMember("test@test.com", "test", MemberStatus.JOIN, "123435345");
 
-		given(notificationRepository.findByIdAndReadFlagNot(anyLong()))
+		given(notificationRepository.findById(anyLong()))
 			.willReturn(Optional.empty());
 
 		// when, then

--- a/src/test/java/com/eggmeonina/scrumble/fixture/NotificationFixture.java
+++ b/src/test/java/com/eggmeonina/scrumble/fixture/NotificationFixture.java
@@ -16,7 +16,7 @@ import com.google.gson.JsonObject;
 public class NotificationFixture {
 
 	public static Notification createNotification(Member newMember, NotificationType notificationType,
-		boolean readFlag) {
+		boolean readFlag, NotificationStatus notificationStatus) {
 		JsonObject jsonObject = new JsonObject();
 		jsonObject.addProperty("userName", newMember.getName());
 		jsonObject.addProperty("squadName", "테스트 스쿼드");
@@ -30,7 +30,7 @@ public class NotificationFixture {
 			.notificationData(jsonObject.toString())
 			.notificationType(notificationType)
 			.readFlag(readFlag)
-			.notificationStatus(NotificationStatus.PENDING)
+			.notificationStatus(notificationStatus)
 			.build();
 	}
 


### PR DESCRIPTION
## 관련 이슈
closed #260

## 작업 사항
<!-- 가장 대표적인 작업 내용 -->
알림 읽기 여부 변경 -> 알림 상태 변경 시 `알림을 찾을 수 없다`라는 실패 응답이 전달됩니다.
**알림 변경 시 조회 조건**으로 `readFlag`가 false 대상만 조회하기 때문입니다.
조회 조건을 변경하고 테스트를 추가하여 문제를 해결했습니다.

### 추가 정보
<!-- 이 PR에 대한 추가적인 정보가 필요하다면 작성해주세요. -->
