### PR TITLE
Feat: SSE heartbeat 메세지 발행 및 broken pipe 오류 해결 (#266, #271)

### DIFF
--- a/src/main/java/com/eggmeonina/scrumble/common/config/AsyncConfig.java
+++ b/src/main/java/com/eggmeonina/scrumble/common/config/AsyncConfig.java
@@ -6,13 +6,14 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 
 @EnableAsync
 @Configuration
 public class AsyncConfig {
 
 	@Bean(name = "taskExecutor")
-	public ThreadPoolTaskExecutor executor(){
+	public ThreadPoolTaskExecutor executor() {
 		ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
 		executor.setCorePoolSize(5); // 기본 쓰레드 크기
 		executor.setQueueCapacity(20);
@@ -22,7 +23,16 @@ public class AsyncConfig {
 		// DiscardOldestPolicy : 오래된 작업을 skip
 		// DiscardPolicy : 처리하려는 작업을 skip
 		// CallerRunsPolicy : 요청한 caller에서 직접 처리
+		executor.setThreadNamePrefix("AsyncExecutor-");
 		executor.setRejectedExecutionHandler(new ThreadPoolExecutor.CallerRunsPolicy());
 		return executor;
+	}
+
+	@Bean(name = "taskScheduler")
+	public ThreadPoolTaskScheduler taskScheduler() {
+		ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
+		scheduler.setPoolSize(5); // 기본 쓰레드 크기
+		scheduler.setThreadNamePrefix("TaskScheduler-");
+		return scheduler;
 	}
 }

--- a/src/main/java/com/eggmeonina/scrumble/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/eggmeonina/scrumble/common/exception/GlobalExceptionHandler.java
@@ -1,12 +1,15 @@
 package com.eggmeonina.scrumble.common.exception;
 
+import java.io.IOException;
+
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.springframework.http.ResponseEntity;
-import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import com.eggmeonina.scrumble.common.domain.ApiResponse;
 
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
@@ -14,11 +17,29 @@ import lombok.extern.slf4j.Slf4j;
 public class GlobalExceptionHandler {
 
 	@ExceptionHandler(ExpectedException.class)
-	public ResponseEntity<ApiResponse<Void>> customHandlerException(ExpectedException e){
+	public ResponseEntity<ApiResponse<Void>> customHandlerException(ExpectedException e) {
 		this.log(e);
 		return ResponseEntity.status(e.getErrorCode().getStatus())
 			.body(ApiResponse.createErrorResponse(e.getStatusCodeValue(), e.getMessage()));
 
+	}
+
+	/**
+	 * SSEEmitter에서 클라이언트의 연결이 종료되면 Broken pipe 오류가 발생한다.
+	 * Broken pipe 예외를 핸들링하고 이외의 IOException은 에러 로그를 출력한다.
+	 * @param e
+	 * @param req
+	 */
+	@ExceptionHandler(IOException.class)
+	public void handlerIOException(IOException e, HttpServletRequest req) {
+		log.debug("req.requestURI = {}, req.getMethod() = {}", req.getRequestURI(), req.getMethod());
+		if (ExceptionUtils.getRootCauseMessage(e).contains("Broken pipe") &&
+			req.getRequestURI().equals("/api/notifications/subscribe")) {
+			log.warn("broken pipe error!! client close connect = {}", ExceptionUtils.getRootCauseMessage(e));
+			return;
+		}
+		log.error("IOException rootCauseMessage = {}", ExceptionUtils.getRootCauseMessage(e));
+		e.printStackTrace();
 	}
 
 	private void log(ExpectedException e) {

--- a/src/main/java/com/eggmeonina/scrumble/domain/notification/domain/NotificationConstants.java
+++ b/src/main/java/com/eggmeonina/scrumble/domain/notification/domain/NotificationConstants.java
@@ -6,5 +6,9 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class NotificationConstants {
 	public static final Long DEFAULT_TIMEOUT = 60L * 1000 * 30;
+	public static final Long START_DELAY_SECONDS = 100L;
+
+	public static final Long DELAY_SECONDS = 5L;
 	public static final String NOTIFICATION_EVENT_NAME = "notificationEvent";
+	public static final String HEARTBEAT_EVENT_NAME = "heartbeatEvent";
 }

--- a/src/main/java/com/eggmeonina/scrumble/domain/notification/listener/NotificationListener.java
+++ b/src/main/java/com/eggmeonina/scrumble/domain/notification/listener/NotificationListener.java
@@ -55,7 +55,7 @@ public class NotificationListener {
 			// notification 전송
 			notificationSender.sendNotification(event.getRecipientId(), createNotificationMessage());
 		} catch (Exception e){
-			log.error("알림 이벤트 처리 실패, event = {}", event);
+			log.error("알림 이벤트 처리 실패, event = {}, e = {}", event, e.getMessage());
 		}
 	}
 

--- a/src/main/java/com/eggmeonina/scrumble/domain/notification/service/NotificationSender.java
+++ b/src/main/java/com/eggmeonina/scrumble/domain/notification/service/NotificationSender.java
@@ -16,4 +16,9 @@ public interface NotificationSender {
 	 * 알림 메세지 전송
 	 */
 	void sendNotification(Long memberId, NotificationMessage message);
+
+	/**
+	 * eventName으로 알림 메세지 전송
+	 */
+	void sendNotification(Long memberId, String eventName, Object message);
 }

--- a/src/main/java/com/eggmeonina/scrumble/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/eggmeonina/scrumble/domain/notification/service/NotificationService.java
@@ -4,7 +4,6 @@ import java.util.List;
 
 import org.springframework.data.domain.Limit;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.eggmeonina.scrumble.common.exception.ErrorCode;
@@ -31,7 +30,7 @@ public class NotificationService {
 	private final NotificationRepository notificationRepository;
 
 	// TODO : Notification 생성 중 오류가 발생한다면?
-	@Transactional(propagation = Propagation.REQUIRES_NEW)
+	@Transactional
 	public Long createNotification(NotificationCreateRequest request) {
 		Member foundMember = memberRepository.findByIdAndMemberStatusNotJOIN(request.getMemberId())
 			.orElseThrow(() -> new ExpectedException(ErrorCode.MEMBER_NOT_FOUND));

--- a/src/main/java/com/eggmeonina/scrumble/domain/notification/service/impl/SseNotificationSender.java
+++ b/src/main/java/com/eggmeonina/scrumble/domain/notification/service/impl/SseNotificationSender.java
@@ -3,9 +3,15 @@ package com.eggmeonina.scrumble.domain.notification.service.impl;
 import static com.eggmeonina.scrumble.domain.notification.domain.NotificationConstants.*;
 
 import java.io.IOException;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ScheduledFuture;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 import org.springframework.stereotype.Service;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
@@ -25,6 +31,9 @@ public class SseNotificationSender implements NotificationSender {
 
 	private final SseEmitterRepository sseEmitterRepository;
 	private final NotificationService notificationService;
+	private final ThreadPoolTaskScheduler taskScheduler;
+	private final Map<Long, ScheduledFuture<?>> scheduleRepository = new ConcurrentHashMap<>();
+
 
 	@Override
 	public SseEmitter subscribe(NotificationSubScribeRequest request) {
@@ -35,17 +44,27 @@ public class SseNotificationSender implements NotificationSender {
 		// client에게 전달할 메세지 생성
 		NotificationMessage notificationMessage =
 			new NotificationMessage(notificationService.hasUnreadNotifications(request, request.getMemberId()));
-		sendNotification(request.getMemberId(), notificationMessage);
+		sendNotification(request.getMemberId(), NOTIFICATION_EVENT_NAME, notificationMessage);
+
+		// heartbeat 발행
+		ScheduledFuture<?> future = taskScheduler.scheduleWithFixedDelay(() -> sendHeartbeat(request.getMemberId()),
+			Instant.now().plusSeconds(START_DELAY_SECONDS),
+			Duration.ofSeconds(DELAY_SECONDS));
+
+		// future를 스케줄 저장소에 등록
+		scheduleRepository.put(request.getMemberId(), future);
 
 		// sseEmitter의 연결 상태에 따른 콜백 메서드
 		// onCompletion : 정상적으로 연결을 종료했을 때
 		// onTimeout : 타임아웃 시간에 의해 연결이 끊겼을 때
 		// onError : 클라이언트와의 연결이 비정상 종료되었을 때
-		sseEmitter.onCompletion(() -> sseEmitterRepository.deleteById(request.getMemberId()));
-		sseEmitter.onTimeout(() -> sseEmitterRepository.deleteById(request.getMemberId()));
-		sseEmitter.onError(throwable -> {
-			log.error("sseEmitter error memberId : {}, ex : {}", request.getMemberId(), throwable.getMessage());
-			sseEmitterRepository.deleteById(request.getMemberId());
+		sseEmitter.onCompletion(() -> {
+			log.debug("call onCompletion, memberId = {}", request.getMemberId());
+			removeClient(request.getMemberId());
+		});
+		sseEmitter.onTimeout(() -> {
+			log.debug("call onTimeout, memberId = {}", request.getMemberId());
+			sseEmitter.complete();
 		});
 
 		// 클라이언트가 감지할 이벤트를 응답한다.
@@ -54,21 +73,49 @@ public class SseNotificationSender implements NotificationSender {
 
 	@Override
 	public void sendNotification(Long memberId, NotificationMessage message) {
+		sendNotification(memberId, NOTIFICATION_EVENT_NAME, message);
+	}
+
+	@Override
+	public void sendNotification(Long memberId, String eventName, Object message){
 		// memberId 기준으로 저장된 SseEmitter를 조회한다.
 		SseEmitter sseEmitter = sseEmitterRepository.get(memberId);
 		if (sseEmitter == null) {
-			log.debug("sendNotification sseEmitter nul!! memberId = {}", memberId);
+			log.debug("sendNotification sseEmitter null!! memberId = {}", memberId);
 			return;
 		}
 
 		try {
-			sseEmitter.send(SseEmitter.event().id(String.valueOf(memberId)).name(NOTIFICATION_EVENT_NAME)
+			sseEmitter.send(SseEmitter.event().id(String.valueOf(memberId))
+				.name(eventName)
 				.data(new ResponseEntity<>(message, HttpStatus.OK)));
 		} catch (IOException e) {
-			sseEmitterRepository.deleteById(memberId);
-			sseEmitter.completeWithError(e);
+			if (e.getMessage() != null && e.getMessage().contains("Broken pipe")) {
+				log.warn("Ignoring Broken pipe task. client connection closed.");
+			} else {
+				log.error("sseEmitter error memberId : {}, ex : {}", memberId, e.getMessage());
+			}
 		}
 	}
 
+	private void sendHeartbeat(Long memberId) {
+		sendNotification(memberId, HEARTBEAT_EVENT_NAME, "ping");
+	}
+
+	private void removeClient(Long memberId) {
+		log.debug("call removeClient, memberId = {}", memberId);
+		SseEmitter sseEmitter = sseEmitterRepository.get(memberId);
+		if (sseEmitter != null) {
+			log.debug("removeClient sseEmitter!! memberId = {}", memberId);
+			sseEmitterRepository.deleteById(memberId);
+		}
+
+		// 스케줄러에 예정된 스케줄 취소
+		ScheduledFuture<?> scheduledFuture = scheduleRepository.get(memberId);
+		if (scheduledFuture != null) {
+			scheduleRepository.remove(memberId);
+			scheduledFuture.cancel(true);
+		}
+	}
 
 }


### PR DESCRIPTION
## 관련 이슈
close #266 #271

## 작업 사항
<!-- 가장 대표적인 작업 내용 -->
1. heartbeat 메세지 발행
SSE 연결이 로드 밸런서의 `readTimeOut` 시간마다 종료되어 재연결되었습니다. 잦은 재연결 문제를 해결하기 위해 heartbeat 이벤트를 추가하였습니다.
스프링의 `ThreadPoolTaskScheduler` 클래스를 활용하여 지정한 `delayTime`마다 SSE 이벤트를 전송합니다.

2. broken pipe 오류 해결
클라이언트에서 연결이 끊기는 경우, `IOException`이 발생하면서 broken pipe 오류가 발생합니다.
동기적인 호출이면 `try-catch`에 의해 에러 로그가 발생하지 않았겠지만 `SseEmitter`는 비동기로 작동합니다.
이 문제를 해결하기 위해 특정 uri에서 `IOException`의 `Broken pipe`가 발생하면 `warning` 레벨로 로그를 작성하도록 구현했습니다. (화이트 리스트 관리)

3. Sse 에러 핸들링 방식 변경
코멘트로 남겨두겠습니다.

### 추가 정보
<!-- 이 PR에 대한 추가적인 정보가 필요하다면 작성해주세요. -->
