### PR TITLE
Feat: 회원 탈퇴 시 리더 제약사항, 스쿼드 탈퇴/삭제 로직 추가

### DIFF
--- a/src/main/java/com/eggmeonina/scrumble/domain/member/controller/UserController.java
+++ b/src/main/java/com/eggmeonina/scrumble/domain/member/controller/UserController.java
@@ -19,6 +19,7 @@ import com.eggmeonina.scrumble.domain.member.dto.MemberInvitationResponse;
 import com.eggmeonina.scrumble.domain.member.dto.MemberRenameRequest;
 import com.eggmeonina.scrumble.domain.member.dto.MemberResponse;
 import com.eggmeonina.scrumble.domain.member.service.MemberService;
+import com.eggmeonina.scrumble.domain.member.service.MemberWithdrawService;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -34,6 +35,7 @@ import lombok.RequiredArgsConstructor;
 public class UserController {
 
 	private final MemberService memberService;
+	private final MemberWithdrawService memberWithdrawService;
 
 	@GetMapping("/me")
 	@Operation(summary = "나의 회원 정보 조회", description = "나의 회원 정보를 조회한다.")
@@ -49,7 +51,7 @@ public class UserController {
 		if (session == null) {
 			throw new MemberException(UNAUTHORIZED_ACCESS);
 		}
-		memberService.withdraw(member.getId());
+		memberWithdrawService.withdraw(member.getId());
 		session.invalidate();
 		return ApiResponse.createSuccessWithNoContentResponse(HttpStatus.OK.value());
 	}

--- a/src/main/java/com/eggmeonina/scrumble/domain/member/service/MemberService.java
+++ b/src/main/java/com/eggmeonina/scrumble/domain/member/service/MemberService.java
@@ -36,13 +36,6 @@ public class MemberService {
 		return MemberResponse.from(foundMember);
 	}
 
-	@Transactional
-	public void withdraw(Long memberId) {
-		Member foundMember = memberRepository.findById(memberId)
-			.orElseThrow(() -> new MemberException(MEMBER_NOT_FOUND));
-		foundMember.withdraw();
-	}
-
 	public MemberInvitationResponse findMember(String email){
 		Member foundMember = memberRepository.findByEmail(email)
 			.orElseThrow(() -> new MemberException(MEMBER_NOT_FOUND));

--- a/src/main/java/com/eggmeonina/scrumble/domain/member/service/MemberWithdrawService.java
+++ b/src/main/java/com/eggmeonina/scrumble/domain/member/service/MemberWithdrawService.java
@@ -1,0 +1,74 @@
+package com.eggmeonina.scrumble.domain.member.service;
+
+import static com.eggmeonina.scrumble.common.exception.ErrorCode.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.eggmeonina.scrumble.common.exception.ErrorCode;
+import com.eggmeonina.scrumble.common.exception.ExpectedException;
+import com.eggmeonina.scrumble.common.exception.MemberException;
+import com.eggmeonina.scrumble.domain.member.domain.Member;
+import com.eggmeonina.scrumble.domain.member.repository.MemberRepository;
+import com.eggmeonina.scrumble.domain.squadmember.domain.SquadMember;
+import com.eggmeonina.scrumble.domain.squadmember.repository.SquadMemberRepository;
+import com.eggmeonina.scrumble.domain.squadmember.repository.SquadRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class MemberWithdrawService {
+
+	private final MemberRepository memberRepository;
+	private final SquadRepository squadRepository;
+	private final SquadMemberRepository squadMemberRepository;
+
+	/**
+	 * 회원을 탈퇴한다.
+	 * 단, 리더인 스쿼드가 있는 경우
+	 * 팀원이 없으면 스쿼드 탈퇴, 스쿼드 삭제, 회원 탈퇴를 한다.
+	 * 팀원이 있으면 예외를 발생시키고 회원 탈퇴하지 못한다.
+	 *
+	 * @param memberId
+	 */
+	@Transactional
+	public void withdraw(Long memberId) {
+		Member foundMember = memberRepository.findByIdAndMemberStatusNotJOIN(memberId)
+			.orElseThrow(() -> new MemberException(MEMBER_NOT_FOUND));
+
+		// 스쿼드들을 조회한다.
+		List<SquadMember> squadMembers = squadMemberRepository.findByMemberIdWithJOIN(memberId);
+
+		// 스쿼드의 리더일 때, 회원이 존재하는 스쿼드면 throw 발생시킨다.
+		for (SquadMember squadMember : squadMembers) {
+			if (squadMember.isLeader() && squadMemberRepository.existsBySquadMemberNotMemberId(
+				squadMember.getSquad().getId(), memberId)) {
+				throw new ExpectedException(ErrorCode.LEADER_CANNOT_LEAVE);
+			}
+		}
+		List<Long> squadMemberIdList = squadMembers.stream()
+			.map(SquadMember::getId)
+			.toList();
+
+		List<Long> squadIdList = squadMembers.stream()
+			.filter(SquadMember::isLeader)
+			.map(squadMember -> squadMember.getSquad().getId())
+			.toList();
+
+		// 스쿼드를 탈퇴한다.
+		if (!squadMemberIdList.isEmpty()) {
+			squadMemberRepository.bulkLeaveSquadMember(squadMemberIdList, LocalDateTime.now());
+		}
+		// 리더인 스쿼드를 삭제한다.
+		if (!squadIdList.isEmpty()) {
+			squadRepository.bulkDeleteSquads(squadIdList, LocalDateTime.now());
+		}
+
+		foundMember.withdraw();
+	}
+}

--- a/src/main/java/com/eggmeonina/scrumble/domain/squadmember/repository/SquadMemberRepository.java
+++ b/src/main/java/com/eggmeonina/scrumble/domain/squadmember/repository/SquadMemberRepository.java
@@ -1,9 +1,11 @@
 package com.eggmeonina.scrumble.domain.squadmember.repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
@@ -27,9 +29,25 @@ public interface SquadMemberRepository extends JpaRepository<SquadMember, Long>,
 	List<SquadMember> findBySquadId(final Long squadId);
 
 	@Query("""
+		 SELECT s
+		   FROM SquadMember s
+		  WHERE s.member.id = :memberId AND s.squadMemberStatus = 'JOIN'
+		""")
+	List<SquadMember> findByMemberIdWithJOIN(final Long memberId);
+
+	@Query("""
 		SELECT s
 		  FROM SquadMember s
 		 WHERE s.member.id = :memberId AND s.squad.id = :squadId AND s.squadMemberStatus = 'INVITING'
 		""")
 	Optional<SquadMember> findByMemberIdAndSquadIdWithInvitingStatus(final Long memberId, final Long squadId);
+
+	@Modifying
+	@Query("""
+		UPDATE SquadMember s
+		   SET s.squadMemberStatus = 'LEAVE'
+		     , s.updatedAt = :updatedAt
+		 WHERE s.id in (:squadMemberIds)
+		""")
+	void bulkLeaveSquadMember(List<Long> squadMemberIds, LocalDateTime updatedAt);
 }

--- a/src/main/java/com/eggmeonina/scrumble/domain/squadmember/repository/SquadRepository.java
+++ b/src/main/java/com/eggmeonina/scrumble/domain/squadmember/repository/SquadRepository.java
@@ -1,8 +1,11 @@
 package com.eggmeonina.scrumble.domain.squadmember.repository;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
@@ -17,4 +20,14 @@ public interface SquadRepository extends JpaRepository<Squad, Long>, SquadReposi
 		 WHERE s.id = :squadId AND s.deletedFlag = false
 		""")
 	Optional<Squad> findByIdAndDeletedFlagNot(Long squadId);
+
+	@Modifying
+	@Query("""
+		UPDATE Squad s
+		   SET s.deletedFlag = true
+		     , s.updatedAt = :updatedAt
+		 WHERE s.id in (:squadIds)
+		""")
+	void bulkDeleteSquads(List<Long> squadIds, LocalDateTime updatedAt);
+
 }

--- a/src/test/java/com/eggmeonina/scrumble/domain/member/controller/UserControllerTest.java
+++ b/src/test/java/com/eggmeonina/scrumble/domain/member/controller/UserControllerTest.java
@@ -4,6 +4,7 @@ import static com.eggmeonina.scrumble.common.exception.ErrorCode.*;
 import static org.mockito.BDDMockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.request;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 import java.time.LocalDateTime;
@@ -27,6 +28,7 @@ import com.eggmeonina.scrumble.domain.member.domain.SessionKey;
 import com.eggmeonina.scrumble.domain.member.dto.MemberResponse;
 import com.eggmeonina.scrumble.domain.member.repository.MemberRepository;
 import com.eggmeonina.scrumble.domain.member.service.MemberService;
+import com.eggmeonina.scrumble.domain.member.service.MemberWithdrawService;
 import com.eggmeonina.scrumble.helper.WebMvcTestHelper;
 
 class UserControllerTest extends WebMvcTestHelper {
@@ -36,6 +38,9 @@ class UserControllerTest extends WebMvcTestHelper {
 
 	@MockBean
 	private MemberService memberService;
+
+	@MockBean
+	private MemberWithdrawService memberWithdrawService;
 
 	@MockBean
 	private MemberRepository memberRepository;
@@ -102,7 +107,7 @@ class UserControllerTest extends WebMvcTestHelper {
 		session.setAttribute(
 			SessionKey.LOGIN_USER.name(), memberInfo
 		);
-
+		doNothing().when(memberWithdrawService).withdraw(anyLong());
 		given(memberRepository.findByIdAndMemberStatusNotJOIN(anyLong())).willReturn(
 			Optional.of(
 				new Member(memberInfo.getMemberId(), memberInfo.getEmail(), memberInfo.getName(), null, null,

--- a/src/test/java/com/eggmeonina/scrumble/domain/member/service/LoginMemberServiceIntegrationTest.java
+++ b/src/test/java/com/eggmeonina/scrumble/domain/member/service/LoginMemberServiceIntegrationTest.java
@@ -13,7 +13,6 @@ import com.eggmeonina.scrumble.domain.auth.domain.MemberInformation;
 import com.eggmeonina.scrumble.domain.auth.domain.OauthType;
 import com.eggmeonina.scrumble.domain.auth.dto.MemberInfo;
 import com.eggmeonina.scrumble.domain.member.domain.Member;
-import com.eggmeonina.scrumble.domain.member.domain.MemberStatus;
 import com.eggmeonina.scrumble.domain.member.dto.MemberResponse;
 import com.eggmeonina.scrumble.domain.member.repository.MemberRepository;
 import com.eggmeonina.scrumble.fixture.MemberFixture;
@@ -91,31 +90,6 @@ class MemberServiceIntegrationTest extends IntegrationTestHelper {
 			.hasMessageContaining(MEMBER_NOT_FOUND.getMessage());
 	}
 
-	@Test
-	@DisplayName("회원을 탈퇴한다_성공")
-	void withdraw_success() {
-		// given
-		MemberInformation request = new MemberInformation("123456789", "test@naver.com", "testName", "");
-
-		Member newMember = MemberInformation.to(request, OauthType.GOOGLE);
-		memberRepository.save(newMember);
-
-		// when
-		memberService.withdraw(newMember.getId());
-
-		Member foundMember = memberRepository.findById(newMember.getId()).get();
-
-		// then
-		assertThat(foundMember.getMemberStatus()).isEqualTo(MemberStatus.WITHDRAW);
-	}
-
-	@Test
-	@DisplayName("존재하지 않는 회원을 탈퇴 요청하면 예외가 발생한다_실패")
-	void withdraw_fail_throwsException() {
-		assertThatThrownBy(()-> memberService.withdraw(1L))
-			.isInstanceOf(MemberException.class)
-			.hasMessageContaining(MEMBER_NOT_FOUND.getMessage());
-	}
 
 	@Test
 	@DisplayName("회원의 이름을 변경한다_성공")

--- a/src/test/java/com/eggmeonina/scrumble/domain/member/service/MemberWithdrawServiceIntegrationTest.java
+++ b/src/test/java/com/eggmeonina/scrumble/domain/member/service/MemberWithdrawServiceIntegrationTest.java
@@ -1,0 +1,152 @@
+package com.eggmeonina.scrumble.domain.member.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.SoftAssertions.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import com.eggmeonina.scrumble.common.exception.ErrorCode;
+import com.eggmeonina.scrumble.common.exception.ExpectedException;
+import com.eggmeonina.scrumble.domain.member.domain.Member;
+import com.eggmeonina.scrumble.domain.member.domain.MemberStatus;
+import com.eggmeonina.scrumble.domain.member.repository.MemberRepository;
+import com.eggmeonina.scrumble.domain.squadmember.domain.Squad;
+import com.eggmeonina.scrumble.domain.squadmember.domain.SquadMember;
+import com.eggmeonina.scrumble.domain.squadmember.domain.SquadMemberRole;
+import com.eggmeonina.scrumble.domain.squadmember.domain.SquadMemberStatus;
+import com.eggmeonina.scrumble.domain.squadmember.repository.SquadMemberRepository;
+import com.eggmeonina.scrumble.domain.squadmember.repository.SquadRepository;
+import com.eggmeonina.scrumble.fixture.MemberFixture;
+import com.eggmeonina.scrumble.fixture.SquadMemberFixture;
+import com.eggmeonina.scrumble.helper.IntegrationTestHelper;
+
+class MemberWithdrawServiceIntegrationTest extends IntegrationTestHelper {
+
+	@Autowired
+	private MemberWithdrawService memberWithdrawService;
+
+	@Autowired
+	private SquadMemberRepository squadMemberRepository;
+
+	@Autowired
+	private SquadRepository squadRepository;
+
+	@Autowired
+	private MemberRepository memberRepository;
+
+	@Test
+	@DisplayName("회원이 탈퇴한다_성공")
+	void withdraw_whenNotLeader_success() {
+		// given
+		Member 테스트유저1 = MemberFixture.createJOINMember("test@test.com", "테스트유저1", "123234235");
+		memberRepository.save(테스트유저1);
+
+		// when
+		memberWithdrawService.withdraw(테스트유저1.getId());
+		Member foundMember = memberRepository.findById(테스트유저1.getId()).get();
+
+		// // then
+		assertThat(foundMember.getMemberStatus()).isEqualTo(MemberStatus.WITHDRAW);
+	}
+
+	@Test
+	@DisplayName("스쿼드에 팀원이 없는 리더인 회원이 탈퇴한다_성공")
+	void withdraw_WhenRoleIsLeader_success1() {
+		// given
+		Member 테스트유저1 = MemberFixture.createJOINMember("test@test.com", "테스트유저1", "123234235");
+
+		Squad 테스트스쿼드 = SquadMemberFixture.createSquad("테스트스쿼드");
+
+		SquadMember leader = SquadMemberFixture.createSquadMember(테스트스쿼드, 테스트유저1, SquadMemberRole.LEADER,
+			SquadMemberStatus.JOIN);
+
+		memberRepository.saveAll(List.of(테스트유저1));
+		squadRepository.save(테스트스쿼드);
+		squadMemberRepository.saveAll(List.of(leader));
+
+		// when
+		memberWithdrawService.withdraw(테스트유저1.getId());
+
+		Member foundMember = memberRepository.findById(테스트유저1.getId()).get();
+		SquadMember foundSquadMember = squadMemberRepository.findById(leader.getId()).get();
+		Squad foundSquad = squadRepository.findById(테스트스쿼드.getId()).get();
+
+		// then
+		assertSoftly(softly -> {
+			softly.assertThat(foundMember.getMemberStatus()).isEqualTo(MemberStatus.WITHDRAW);
+			softly.assertThat(foundSquadMember.getSquadMemberStatus()).isEqualTo(SquadMemberStatus.LEAVE);
+			softly.assertThat(foundSquad.isDeletedFlag()).isTrue();
+		});
+	}
+
+	@Test
+	@DisplayName("스쿼드에 팀원이 있는 리더인 회원이 탈퇴한다_실패")
+	void withdraw_WhenRoleIsLeader_success2() {
+		// given
+		Member 테스트유저1 = MemberFixture.createJOINMember("test@test.com", "테스트유저1", "123234235");
+		Member 테스트유저2 = MemberFixture.createJOINMember("test@test.com", "테스트유저1", "123234235");
+
+		Squad 테스트스쿼드 = SquadMemberFixture.createSquad("테스트스쿼드");
+
+		SquadMember leader = SquadMemberFixture.createSquadMember(테스트스쿼드, 테스트유저1, SquadMemberRole.LEADER,
+			SquadMemberStatus.JOIN);
+		SquadMember normalSquadMember = SquadMemberFixture.createSquadMember(테스트스쿼드, 테스트유저2, SquadMemberRole.NORMAL, SquadMemberStatus.JOIN);
+
+		memberRepository.saveAll(List.of(테스트유저1, 테스트유저2));
+		squadRepository.save(테스트스쿼드);
+		squadMemberRepository.saveAll(List.of(leader, normalSquadMember));
+
+		// when
+		assertThatThrownBy(() -> memberWithdrawService.withdraw(테스트유저1.getId()))
+			.isInstanceOf(ExpectedException.class)
+			.hasMessageContaining(ErrorCode.LEADER_CANNOT_LEAVE.getMessage());
+
+		Member foundMember = memberRepository.findById(테스트유저1.getId()).get();
+		SquadMember foundSquadMember = squadMemberRepository.findById(normalSquadMember.getId()).get();
+		Squad foundSquad = squadRepository.findById(테스트스쿼드.getId()).get();
+
+		// then
+		assertSoftly(softly -> {
+			softly.assertThat(foundMember.getMemberStatus()).isEqualTo(MemberStatus.JOIN);
+			softly.assertThat(foundSquadMember.getSquadMemberStatus()).isEqualTo(SquadMemberStatus.JOIN);
+			softly.assertThat(foundSquad.isDeletedFlag()).isFalse();
+		});
+	}
+
+	@Test
+	@DisplayName("리더가 아닌 회원이 탈퇴한다_성공")
+	void withdraw_WhenRoleIsNormal_success() {
+		// given
+		Member 테스트유저1 = MemberFixture.createJOINMember("test@test.com", "테스트유저1", "123234235");
+		Member 테스트유저2 = MemberFixture.createJOINMember("test@test.com", "테스트유저1", "123234235");
+
+		Squad 테스트스쿼드 = SquadMemberFixture.createSquad("테스트스쿼드");
+
+		SquadMember leader = SquadMemberFixture.createSquadMember(테스트스쿼드, 테스트유저1, SquadMemberRole.LEADER,
+			SquadMemberStatus.JOIN);
+		SquadMember normalSquadMember = SquadMemberFixture.createSquadMember(테스트스쿼드, 테스트유저2, SquadMemberRole.NORMAL, SquadMemberStatus.JOIN);
+
+		memberRepository.saveAll(List.of(테스트유저1, 테스트유저2));
+		squadRepository.save(테스트스쿼드);
+		squadMemberRepository.saveAll(List.of(leader, normalSquadMember));
+
+		// when
+		memberWithdrawService.withdraw(테스트유저2.getId());
+
+		Member foundMember = memberRepository.findById(테스트유저2.getId()).get();
+		SquadMember foundSquadMember = squadMemberRepository.findById(normalSquadMember.getId()).get();
+		Squad foundSquad = squadRepository.findById(테스트스쿼드.getId()).get();
+
+		// then
+		assertSoftly(softly -> {
+			softly.assertThat(foundMember.getMemberStatus()).isEqualTo(MemberStatus.WITHDRAW);
+			softly.assertThat(foundSquadMember.getSquadMemberStatus()).isEqualTo(SquadMemberStatus.LEAVE);
+			softly.assertThat(foundSquad.isDeletedFlag()).isFalse();
+		});
+	}
+
+}

--- a/src/test/java/com/eggmeonina/scrumble/domain/member/service/MemberWithdrawServiceTest.java
+++ b/src/test/java/com/eggmeonina/scrumble/domain/member/service/MemberWithdrawServiceTest.java
@@ -1,0 +1,74 @@
+package com.eggmeonina.scrumble.domain.member.service;
+
+import static com.eggmeonina.scrumble.fixture.SquadMemberFixture.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.eggmeonina.scrumble.common.exception.ErrorCode;
+import com.eggmeonina.scrumble.common.exception.ExpectedException;
+import com.eggmeonina.scrumble.domain.member.domain.Member;
+import com.eggmeonina.scrumble.domain.member.repository.MemberRepository;
+import com.eggmeonina.scrumble.domain.squadmember.domain.Squad;
+import com.eggmeonina.scrumble.domain.squadmember.domain.SquadMember;
+import com.eggmeonina.scrumble.domain.squadmember.domain.SquadMemberRole;
+import com.eggmeonina.scrumble.domain.squadmember.domain.SquadMemberStatus;
+import com.eggmeonina.scrumble.domain.squadmember.repository.SquadMemberRepository;
+import com.eggmeonina.scrumble.fixture.MemberFixture;
+
+@ExtendWith(MockitoExtension.class)
+class MemberWithdrawServiceTest {
+
+	@InjectMocks
+	private MemberWithdrawService memberWithdrawService;
+	@Mock
+	private MemberRepository memberRepository;
+	@Mock
+	private SquadMemberRepository squadMemberRepository;
+
+	@Test
+	@DisplayName("회원이 존재하지 않을 때 회원 탈퇴한다_실패")
+	void leaveMember_whenNotExistMember_fail() {
+		// given
+		given(memberRepository.findByIdAndMemberStatusNotJOIN(anyLong()))
+			.willReturn(Optional.empty());
+		
+		// when, then
+		assertThatThrownBy(() -> memberWithdrawService.withdraw(1L))
+			.hasMessageContaining(ErrorCode.MEMBER_NOT_FOUND.getMessage())
+			.isInstanceOf(ExpectedException.class);
+	}
+
+	@Test
+	@DisplayName("팀원이 존재하는 스쿼드의 리더가 회원 탈퇴한다_실패")
+	void leaveMember_whenSquadLeader_fail() {
+		// given
+		Member 테스트유저 = MemberFixture.createJOINMember("test@test.com", "테스트 유저", "123345");
+		Squad 테스트스쿼드 = createSquad("테스트스쿼드");
+		SquadMember 스쿼드멤버1 = createSquadMember(테스트스쿼드, 테스트유저, SquadMemberRole.LEADER,
+			SquadMemberStatus.JOIN);
+		List<SquadMember> squadMembers = createSquadMembers(스쿼드멤버1);
+
+		given(memberRepository.findByIdAndMemberStatusNotJOIN(anyLong()))
+			.willReturn(Optional.of(테스트유저));
+		given(squadMemberRepository.findByMemberIdWithJOIN(anyLong()))
+			.willReturn(squadMembers);
+		given(squadMemberRepository.existsBySquadMemberNotMemberId(any(), any()))
+			.willReturn(Boolean.TRUE);
+
+		// when, then
+		assertThatThrownBy(() -> memberWithdrawService.withdraw(1L))
+			.hasMessageContaining(ErrorCode.LEADER_CANNOT_LEAVE.getMessage())
+			.isInstanceOf(ExpectedException.class);
+	}
+
+}


### PR DESCRIPTION
## 관련 이슈
close #47 

## 작업 사항
<!-- 가장 대표적인 작업 내용 -->
회원탈퇴 하는 경우 제약사항과 스쿼드 탈퇴/삭제 로직을 추가하였습니다.
회원이 탈퇴를 하면 스쿼드에서 활동을 할 수 없기 때문에 스쿼드는 탈퇴처리합니다. 이때, ToDo는 유지합니다.

리더인 경우에는 아래와 같이 로직이 진행됩니다.
팀원이 없는 스쿼드
- 스쿼드 삭제, 스쿼드 탈퇴
팀원이 있는 스쿼드
- 리더 회원 탈퇴 불가

### 추가 정보
<!-- 이 PR에 대한 추가적인 정보가 필요하다면 작성해주세요. -->
