### PR TITLE
Fix: 리더가 스쿼드 탈퇴하는 경우, 스쿼드 실시간 삭제 (#307)

### DIFF
--- a/src/test/java/com/eggmeonina/scrumble/domain/squadmember/service/SquadMemberServiceAndSquadIntegrationTest.java
+++ b/src/test/java/com/eggmeonina/scrumble/domain/squadmember/service/SquadMemberServiceAndSquadIntegrationTest.java
@@ -356,9 +356,11 @@ class SquadMemberServiceAndSquadIntegrationTest extends IntegrationTestHelper {
 		squadMemberService.leaveSquad(newSquad.getId(), newMember.getId());
 
 		SquadMember foundMember = squadMemberRepository.findById(newSquadMember.getId()).get();
+		Squad foundSquad = squadRepository.findById(newSquad.getId()).get();
 
 		// then
 		assertThat(foundMember.getSquadMemberStatus()).isEqualTo(SquadMemberStatus.LEAVE);
+		assertThat(foundSquad.isDeletedFlag()).isTrue();
 	}
 
 	@Test
@@ -387,9 +389,11 @@ class SquadMemberServiceAndSquadIntegrationTest extends IntegrationTestHelper {
 		squadMemberService.leaveSquad(newSquad.getId(), newMember1.getId());
 
 		SquadMember foundMember = squadMemberRepository.findById(newSquadMember1.getId()).get();
+		Squad foundSquad = squadRepository.findById(newSquad.getId()).get();
 
 		// then
 		assertThat(foundMember.getSquadMemberStatus()).isEqualTo(SquadMemberStatus.LEAVE);
+		assertThat(foundSquad.isDeletedFlag()).isTrue();
 	}
 
 	@Test

--- a/src/test/java/com/eggmeonina/scrumble/domain/squadmember/service/SquadMemberServiceTest.java
+++ b/src/test/java/com/eggmeonina/scrumble/domain/squadmember/service/SquadMemberServiceTest.java
@@ -198,6 +198,8 @@ class SquadMemberServiceTest {
 		SquadMember squadMember = createSquadMember(newSquad, newLeader, SquadMemberRole.NORMAL,
 			SquadMemberStatus.JOIN);
 
+		given(squadRepository.findByIdAndDeletedFlagNot(anyLong()))
+			.willReturn(Optional.ofNullable(newSquad));
 		given(squadMemberRepository.findByMemberIdAndSquadId(anyLong(), anyLong()))
 			.willReturn(Optional.ofNullable(squadMember));
 
@@ -220,6 +222,9 @@ class SquadMemberServiceTest {
 		SquadMember squadMember = createSquadMember(newSquad, newLeader, SquadMemberRole.LEADER,
 			SquadMemberStatus.JOIN);
 
+
+		given(squadRepository.findByIdAndDeletedFlagNot(anyLong()))
+			.willReturn(Optional.ofNullable(newSquad));
 		given(squadMemberRepository.findByMemberIdAndSquadId(anyLong(), anyLong()))
 			.willReturn(Optional.ofNullable(squadMember));
 		given(squadMemberRepository.existsBySquadMemberNotMemberId(anyLong(), anyLong()))
@@ -231,6 +236,7 @@ class SquadMemberServiceTest {
 		// then
 		assert squadMember != null;
 		assertThat(squadMember.getSquadMemberStatus()).isEqualTo(SquadMemberStatus.LEAVE);
+		assertThat(newSquad.isDeletedFlag()).isTrue();
 	}
 
 	@Test
@@ -244,6 +250,8 @@ class SquadMemberServiceTest {
 		SquadMember squadMember = createSquadMember(newSquad, newLeader, SquadMemberRole.LEADER,
 			SquadMemberStatus.JOIN);
 
+		given(squadRepository.findByIdAndDeletedFlagNot(anyLong()))
+			.willReturn(Optional.ofNullable(newSquad));
 		given(squadMemberRepository.findByMemberIdAndSquadId(anyLong(), anyLong()))
 			.willReturn(Optional.ofNullable(squadMember));
 		given(squadMemberRepository.existsBySquadMemberNotMemberId(anyLong(), anyLong()))
@@ -259,8 +267,13 @@ class SquadMemberServiceTest {
 	@DisplayName("존재하지 않는 스쿼드 멤버가 탈퇴 요청한다_실패")
 	void leaveSquadWhenMemberNotInSquad_fail() {
 		// given
+		Squad newSquad = createSquad("테스트 스쿼드");
+
+		given(squadRepository.findByIdAndDeletedFlagNot(anyLong()))
+			.willReturn(Optional.ofNullable(newSquad));
 		given(squadMemberRepository.findByMemberIdAndSquadId(anyLong(), anyLong()))
 			.willReturn(Optional.empty());
+
 		// when, then
 		assertThatThrownBy(() -> squadMemberService.leaveSquad(1L, 1L))
 			.isInstanceOf(SquadMemberException.class)


### PR DESCRIPTION
## 관련 이슈
#307 

## 작업 사항
<!-- 가장 대표적인 작업 내용 -->
리더가 스쿼드를 탈퇴하는 경우 스쿼드를 실시간 삭제합니다.
스쿼드를 삭제하지 않으면 탈퇴된 스쿼드에 초대했던 회원이 가입할 수 있기 때문에 실시간으로 삭제하였습니다.

### 추가 정보
<!-- 이 PR에 대한 추가적인 정보가 필요하다면 작성해주세요. -->
