### PR TITLE
Feat: 카테고리 도메인 및 수정 기능 추가 (#323)

### DIFF
--- a/src/main/java/com/eggmeonina/scrumble/common/exception/ErrorCode.java
+++ b/src/main/java/com/eggmeonina/scrumble/common/exception/ErrorCode.java
@@ -52,7 +52,13 @@ public enum ErrorCode {
 	 */
 	NOTIFICATION_TYPE_NOT_NULL(HttpStatus.BAD_REQUEST, "알림 타입은 비어있을 수 없습니다."),
 	NOTIFICATION_TYPE_NOT_EXISTS(HttpStatus.BAD_REQUEST, "존재하지 않는 알림 타입입니다."),
-	NOTIFICATION_NOT_FOUND(HttpStatus.BAD_REQUEST, "알림이 존재하지 않습니다.");
+	NOTIFICATION_NOT_FOUND(HttpStatus.BAD_REQUEST, "알림이 존재하지 않습니다."),
+
+	/**
+	 * 카테고리
+	 */
+	CATEGORY_NOT_FOUND(HttpStatus.BAD_REQUEST, "카테고리가 존재하지 않습니다."),
+	CATEGORY_ACCESS_DENIED(HttpStatus.FORBIDDEN, "카테고리 수정 권한이 없습니다.");
 
 	private final HttpStatus status;
 	private final String message;

--- a/src/main/java/com/eggmeonina/scrumble/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/eggmeonina/scrumble/common/exception/GlobalExceptionHandler.java
@@ -4,7 +4,9 @@ import java.io.IOException;
 import java.util.List;
 
 import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -46,7 +48,14 @@ public class GlobalExceptionHandler {
 		log.error("e = {}", e.toString(), e);
 	}
 
-	private void log(ExpectedException e) {
+	@ExceptionHandler(MethodArgumentNotValidException.class)
+	public ResponseEntity<ApiResponse<Void>> handleMethodArgumentNotValidException(MethodArgumentNotValidException e){
+		this.log(e);
+		return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+			.body(ApiResponse.createErrorResponse(HttpStatus.BAD_REQUEST.value(), e.getMessage()));
+	}
+
+	private void log(Exception e){
 		log.warn("{}", e.toString(), e);
 	}
 }

--- a/src/main/java/com/eggmeonina/scrumble/domain/category/controller/CategoryController.java
+++ b/src/main/java/com/eggmeonina/scrumble/domain/category/controller/CategoryController.java
@@ -1,0 +1,40 @@
+package com.eggmeonina.scrumble.domain.category.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.eggmeonina.scrumble.common.anotation.LoginMember;
+import com.eggmeonina.scrumble.common.domain.ApiResponse;
+import com.eggmeonina.scrumble.domain.category.dto.CategoryUpdateRequest;
+import com.eggmeonina.scrumble.domain.category.service.CategoryService;
+import com.eggmeonina.scrumble.domain.member.domain.Member;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@Tag(name ="Category 테스트", description = "카테고리 생성, 삭제 조회용 API")
+@RequestMapping("/api/categories")
+@RequiredArgsConstructor
+@RestController
+public class CategoryController {
+
+	private final CategoryService categoryService;
+
+	@PutMapping
+	@Operation(summary = "카테고리명, 컬러를 수정한다")
+	@Parameter(name = "member", hidden = true)
+	public ApiResponse<Void> updateCategory(
+		@LoginMember Member member,
+		@RequestBody @Valid CategoryUpdateRequest request
+	){
+		categoryService.changeCategory(member.getId(), request);
+		return ApiResponse.createSuccessWithNoContentResponse(HttpStatus.OK.value());
+	}
+
+}

--- a/src/main/java/com/eggmeonina/scrumble/domain/category/domain/Category.java
+++ b/src/main/java/com/eggmeonina/scrumble/domain/category/domain/Category.java
@@ -1,0 +1,58 @@
+package com.eggmeonina.scrumble.domain.category.domain;
+
+import static com.eggmeonina.scrumble.common.exception.ErrorCode.*;
+
+import java.util.Objects;
+
+import com.eggmeonina.scrumble.common.exception.ExpectedException;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "category")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Category {
+
+	@Id
+	@Column(name = "category_id")
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Column(name = "category_name", nullable = false)
+	private String categoryName;
+
+	@Column(name = "color")
+	private String color;
+
+	@Column(name = "member_id")
+	private Long memberId;
+
+	@Builder(builderMethodName = "create")
+	public Category(String categoryName, String color, Long memberId) {
+		this.categoryName = categoryName;
+		this.color = color;
+		this.memberId = memberId;
+	}
+
+	public void updateCategory(Long requesterId, String newCategoryName, String newColor){
+		if (!isOwnedBy(requesterId)) {
+			throw new ExpectedException(CATEGORY_ACCESS_DENIED);
+		}
+		this.categoryName = newCategoryName;
+		this.color = newColor;
+	}
+
+	public boolean isOwnedBy(Long memberId) {
+		return Objects.equals(this.memberId, memberId);
+	}
+}

--- a/src/main/java/com/eggmeonina/scrumble/domain/category/dto/CategoryUpdateRequest.java
+++ b/src/main/java/com/eggmeonina/scrumble/domain/category/dto/CategoryUpdateRequest.java
@@ -1,0 +1,27 @@
+package com.eggmeonina.scrumble.domain.category.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "카테고리의 정보")
+public class CategoryUpdateRequest {
+
+	@NotNull(message = "카테고리 ID는 null일 수 없습니다.")
+	@Schema(description = "수정할 카테고리 ID")
+	private Long categoryId;
+
+	@NotBlank(message = "카테고리명은 비어있거나 null일 수 없습니다.")
+	@Schema(description = "수정할 카테고리명 혹은 기존 카테고리명")
+	private String categoryName;
+
+	@NotBlank(message = "색상은 비어있거나 null일 수 없습니다.")
+	@Schema(description = "수정할 색상 혹은 기존 색상")
+	private String color;
+}

--- a/src/main/java/com/eggmeonina/scrumble/domain/category/repository/CategoryRepository.java
+++ b/src/main/java/com/eggmeonina/scrumble/domain/category/repository/CategoryRepository.java
@@ -1,0 +1,10 @@
+package com.eggmeonina.scrumble.domain.category.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.eggmeonina.scrumble.domain.category.domain.Category;
+
+@Repository
+public interface CategoryRepository extends JpaRepository<Category, Long> {
+}

--- a/src/main/java/com/eggmeonina/scrumble/domain/category/service/CategoryService.java
+++ b/src/main/java/com/eggmeonina/scrumble/domain/category/service/CategoryService.java
@@ -1,0 +1,27 @@
+package com.eggmeonina.scrumble.domain.category.service;
+
+import static com.eggmeonina.scrumble.common.exception.ErrorCode.*;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.eggmeonina.scrumble.common.exception.ExpectedException;
+import com.eggmeonina.scrumble.domain.category.domain.Category;
+import com.eggmeonina.scrumble.domain.category.dto.CategoryUpdateRequest;
+import com.eggmeonina.scrumble.domain.category.repository.CategoryRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class CategoryService {
+
+	private final CategoryRepository categoryRepository;
+	@Transactional
+	public void changeCategory(Long memberId, CategoryUpdateRequest request){
+		Category foundCategory = categoryRepository.findById(request.getCategoryId())
+			.orElseThrow(() -> new ExpectedException(CATEGORY_NOT_FOUND));
+
+		foundCategory.updateCategory(memberId, request.getCategoryName(), request.getColor());
+	}
+}

--- a/src/test/java/com/eggmeonina/scrumble/domain/category/domain/CategoryTest.java
+++ b/src/test/java/com/eggmeonina/scrumble/domain/category/domain/CategoryTest.java
@@ -1,0 +1,54 @@
+package com.eggmeonina.scrumble.domain.category.domain;
+
+import static com.eggmeonina.scrumble.common.exception.ErrorCode.*;
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.eggmeonina.scrumble.common.exception.ExpectedException;
+
+class CategoryTest {
+
+	@Test
+	@DisplayName("카테고리 수정_정상")
+	void update_success() {
+		// given
+		Category newCategory = Category.create()
+			.categoryName("회사")
+			.color("000000")
+			.memberId(1L)
+			.build();
+		
+		// when
+		Long memberId = 1L;
+		String newCategoryName = "집안일";
+		String newColor = "FFFFFF";
+
+		newCategory.updateCategory(memberId, newCategoryName, newColor);
+
+		// then
+		assertThat(newCategory.getCategoryName()).isEqualTo(newCategoryName);
+		assertThat(newCategory.getColor()).isEqualTo(newColor);
+	}
+
+	@Test
+	@DisplayName("권한이 없는 유저가 카테고리 수정_실패")
+	void update_no_authority_fail() {
+		// given
+		Category newCategory = Category.create()
+			.categoryName("회사")
+			.color("000000")
+			.memberId(1L)
+			.build();
+
+		// when
+		Long anotherId = 2L;
+		String newCategoryName = "집안일";
+		String newColor = "FFFFFF";
+
+		assertThatThrownBy(() -> newCategory.updateCategory(anotherId, newCategoryName, newColor))
+			.isInstanceOf(ExpectedException.class)
+			.hasMessageContaining(CATEGORY_ACCESS_DENIED.getMessage());
+	}
+}

--- a/src/test/java/com/eggmeonina/scrumble/domain/category/service/CategoryServiceIntegrationTest.java
+++ b/src/test/java/com/eggmeonina/scrumble/domain/category/service/CategoryServiceIntegrationTest.java
@@ -1,0 +1,74 @@
+package com.eggmeonina.scrumble.domain.category.service;
+
+import static com.eggmeonina.scrumble.common.exception.ErrorCode.*;
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import com.eggmeonina.scrumble.common.exception.ExpectedException;
+import com.eggmeonina.scrumble.domain.category.domain.Category;
+import com.eggmeonina.scrumble.domain.category.dto.CategoryUpdateRequest;
+import com.eggmeonina.scrumble.domain.category.repository.CategoryRepository;
+import com.eggmeonina.scrumble.helper.IntegrationTestHelper;
+
+class CategoryServiceIntegrationTest extends IntegrationTestHelper {
+
+	@Autowired
+	private CategoryService categoryService;
+
+	@Autowired
+	private CategoryRepository categoryRepository;
+
+	@Test
+	@DisplayName("카테고리 수정_정상")
+	void changeCategory_success() {
+		// given
+		Category savedCategory = categoryRepository.save(Category.create()
+			.categoryName("회사")
+			.color("000000")
+			.memberId(1L)
+			.build());
+
+		CategoryUpdateRequest request = new CategoryUpdateRequest(savedCategory.getId(), "집안일", "FFFFFF");
+
+		// when
+		categoryService.changeCategory(1L, request);
+
+		// then
+		Category updatedCategory = categoryRepository.findById(savedCategory.getId()).get();
+		assertThat(updatedCategory.getCategoryName()).isEqualTo("집안일");
+		assertThat(updatedCategory.getColor()).isEqualTo("FFFFFF");
+	}
+
+	@Test
+	@DisplayName("카테고리 수정_권한 없음_실패")
+	void changeCategory_no_permission_fail() {
+		// given
+		Category savedCategory = categoryRepository.save(Category.create()
+			.categoryName("회사")
+			.color("000000")
+			.memberId(1L)
+			.build());
+
+		CategoryUpdateRequest request = new CategoryUpdateRequest(savedCategory.getId(), "집안일", "FFFFFF");
+
+		// when & then
+		assertThatThrownBy(() -> categoryService.changeCategory(2L, request))
+			.isInstanceOf(ExpectedException.class)
+			.hasMessageContaining(CATEGORY_ACCESS_DENIED.getMessage());
+	}
+
+	@Test
+	@DisplayName("카테고리 수정_존재하지 않는 카테고리_실패")
+	void changeCategory_category_not_found_fail() {
+		// given
+		CategoryUpdateRequest request = new CategoryUpdateRequest(999L, "집안일", "FFFFFF");
+
+		// when & then
+		assertThatThrownBy(() -> categoryService.changeCategory(1L, request))
+			.isInstanceOf(ExpectedException.class)
+			.hasMessageContaining(CATEGORY_NOT_FOUND.getMessage());
+	}
+}


### PR DESCRIPTION
## 관련 이슈
#323 

## 작업 사항
<!-- 가장 대표적인 작업 내용 -->
카테고리 도메인 추가 및 수정 기능을 추가하였습니다.
- 본인이 아니면 카테고리를 수정할 수 없습니다.
- 카테고리명, 색상을 수정할 수 있습니다.

### 추가 정보
<!-- 이 PR에 대한 추가적인 정보가 필요하다면 작성해주세요. -->
클로드 AI 리뷰를 위해 PR을 재작성하였습니다.