### PR TITLE
feat: 투두 도메인에 카테고리id 컬럼 추가 (#326)

### DIFF
--- a/src/main/java/com/eggmeonina/scrumble/domain/category/service/CategoryService.java
+++ b/src/main/java/com/eggmeonina/scrumble/domain/category/service/CategoryService.java
@@ -80,4 +80,22 @@ public class CategoryService {
 
 		foundCategory.delete();
 	}
+
+	/**
+	 * 카테고리 권한 검증 - 해당 사용자가 카테고리에 접근할 수 있는지 확인
+	 * @param memberId
+	 * @param categoryId
+	 */
+	@Transactional(readOnly = true)
+	public void validateCategoryAccess(Long memberId, Long categoryId){
+		if(categoryId == null) return;
+		
+		Category foundCategory = categoryRepository.findByIdAndDeletedFlagFalse(categoryId)
+			.orElseThrow(() -> new ExpectedException(CATEGORY_NOT_FOUND));
+
+		if(!foundCategory.isOwnedBy(memberId)){
+			throw new ExpectedException(CATEGORY_ACCESS_DENIED);
+		}
+	}
+
 }

--- a/src/main/java/com/eggmeonina/scrumble/domain/todo/domain/ToDo.java
+++ b/src/main/java/com/eggmeonina/scrumble/domain/todo/domain/ToDo.java
@@ -56,7 +56,7 @@ public class ToDo extends BaseEntity {
 	@JoinColumn(name = "member_id", nullable = false)
 	private Member member;
 
-	@Column(name = "categoryId", nullable = true)
+	@Column(name = "category_id", nullable = true)
 	private Long categoryId;
 
 	@Builder(builderMethodName = "create")

--- a/src/main/java/com/eggmeonina/scrumble/domain/todo/domain/ToDo.java
+++ b/src/main/java/com/eggmeonina/scrumble/domain/todo/domain/ToDo.java
@@ -49,22 +49,26 @@ public class ToDo extends BaseEntity {
 	@Column(name = "todo_at", nullable = false)
 	private LocalDate toDoAt;
 
-	@Column(name = "deleted_flag")
+	@Column(name = "deleted_flag", nullable = false)
 	private boolean deletedFlag;
 
 	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "member_id")
+	@JoinColumn(name = "member_id", nullable = false)
 	private Member member;
+
+	@Column(name = "categoryId", nullable = true)
+	private Long categoryId;
 
 	@Builder(builderMethodName = "create")
 	public ToDo(ToDoType toDoType, String contents, ToDoStatus toDoStatus, LocalDate toDoAt, boolean deletedFlag,
-		Member member) {
+		Member member, Long categoryId) {
 		this.toDoType = toDoType;
 		this.contents = contents;
 		this.toDoStatus = toDoStatus;
 		this.toDoAt = toDoAt;
 		this.deletedFlag = deletedFlag;
 		this.member = member;
+		this.categoryId = categoryId;
 		initValid(member, contents, toDoType);
 	}
 
@@ -84,9 +88,10 @@ public class ToDo extends BaseEntity {
 		this.deletedFlag = true;
 	}
 
-	public void update(String newContents, ToDoStatus newToDoStatus, LocalDate newTodoAt){
+	public void update(String newContents, ToDoStatus newToDoStatus, LocalDate newTodoAt, Long categoryId){
 		this.contents = newContents;
 		this.toDoStatus = newToDoStatus;
 		this.toDoAt = newTodoAt;
+		this.categoryId = categoryId;
 	}
 }

--- a/src/main/java/com/eggmeonina/scrumble/domain/todo/dto/SquadTodoCreateRequest.java
+++ b/src/main/java/com/eggmeonina/scrumble/domain/todo/dto/SquadTodoCreateRequest.java
@@ -18,6 +18,7 @@ public class SquadTodoCreateRequest {
 	private ToDoType toDoType;
 	private String contents;
 	private LocalDate toDoAt;
+	private Long categoryId;
 	public static ToDo to(SquadTodoCreateRequest request, Member member){
 		return ToDo.create()
 			.toDoType(request.getToDoType())
@@ -26,6 +27,7 @@ public class SquadTodoCreateRequest {
 			.toDoAt(request.getToDoAt())
 			.deletedFlag(false)
 			.member(member)
+			.categoryId(request.getCategoryId())
 			.build();
 	}
 }

--- a/src/main/java/com/eggmeonina/scrumble/domain/todo/dto/SquadTodoResponse.java
+++ b/src/main/java/com/eggmeonina/scrumble/domain/todo/dto/SquadTodoResponse.java
@@ -16,13 +16,22 @@ public class SquadTodoResponse {
 	private String contents;
 	private LocalDate toDoAt;
 	private ToDoStatus toDoStatus;
+	private Long categoryId;
+	private String categoryName;
+	private String categoryColor;
 
 	@QueryProjection
-	public SquadTodoResponse(Long toDoId, Long squadToDoId, String contents, LocalDate toDoAt, ToDoStatus toDoStatus) {
+	public SquadTodoResponse(Long toDoId, Long squadToDoId, String contents, LocalDate toDoAt, ToDoStatus toDoStatus,
+		Long categoryId,
+		String categoryName,
+		String categoryColor) {
 		this.toDoId = toDoId;
 		this.squadToDoId = squadToDoId;
 		this.contents = contents;
 		this.toDoAt = toDoAt;
 		this.toDoStatus = toDoStatus;
+		this.categoryId = categoryId;
+		this.categoryName = categoryName;
+		this.categoryColor = categoryColor;
 	}
 }

--- a/src/main/java/com/eggmeonina/scrumble/domain/todo/dto/ToDoDetailResponse.java
+++ b/src/main/java/com/eggmeonina/scrumble/domain/todo/dto/ToDoDetailResponse.java
@@ -17,15 +17,21 @@ public class ToDoDetailResponse {
 	private String contents;
 	private LocalDate todoAt;
 	private ToDoStatus toDoStatus;
+	private Long categoryId;
+	private String categoryName;
+	private String categoryColor;
 
 	@QueryProjection
 	public ToDoDetailResponse(Long toDoId, Long squadId, String squadName, String contents, LocalDate todoAt,
-		ToDoStatus toDoStatus) {
+		ToDoStatus toDoStatus, Long categoryId, String categoryName, String categoryColor) {
 		this.toDoId = toDoId;
 		this.squadId = squadId;
 		this.squadName = squadName;
 		this.contents = contents;
 		this.todoAt = todoAt;
 		this.toDoStatus = toDoStatus;
+		this.categoryId = categoryId;
+		this.categoryName = categoryName;
+		this.categoryColor = categoryColor;
 	}
 }

--- a/src/main/java/com/eggmeonina/scrumble/domain/todo/dto/ToDoUpdateRequest.java
+++ b/src/main/java/com/eggmeonina/scrumble/domain/todo/dto/ToDoUpdateRequest.java
@@ -27,4 +27,7 @@ public class ToDoUpdateRequest {
 	@PastOrPresent
 	@Schema(description = "변경하고자 하는 ToDo 일자 (변경 없으면 기존 일자)")
 	private LocalDate toDoAt;
+	@NotNull(message = "카테고리 Id는 null일 수 없습니다")
+	@Schema(description = "Todo 카테고리 Id")
+	private Long categoryId;
 }

--- a/src/main/java/com/eggmeonina/scrumble/domain/todo/dto/ToDoUpdateRequest.java
+++ b/src/main/java/com/eggmeonina/scrumble/domain/todo/dto/ToDoUpdateRequest.java
@@ -20,14 +20,16 @@ public class ToDoUpdateRequest {
 	@NotBlank
 	@Schema(description = "ToDo 내용")
 	private String contents;
+
 	@NotNull
 	@Schema(description = "ToDo 상태 - PENDING(미완료), COMPLETED(완료)")
 	private ToDoStatus toDoStatus;
+
 	@NotNull
 	@PastOrPresent
 	@Schema(description = "변경하고자 하는 ToDo 일자 (변경 없으면 기존 일자)")
 	private LocalDate toDoAt;
-	@NotNull(message = "카테고리 Id는 null일 수 없습니다")
+
 	@Schema(description = "Todo 카테고리 Id")
 	private Long categoryId;
 }

--- a/src/main/java/com/eggmeonina/scrumble/domain/todo/repository/impl/SquadTodoRepositoryCustomImpl.java
+++ b/src/main/java/com/eggmeonina/scrumble/domain/todo/repository/impl/SquadTodoRepositoryCustomImpl.java
@@ -1,5 +1,6 @@
 package com.eggmeonina.scrumble.domain.todo.repository.impl;
 
+import static com.eggmeonina.scrumble.domain.category.domain.QCategory.*;
 import static com.eggmeonina.scrumble.domain.squadmember.domain.QSquadMember.*;
 import static com.eggmeonina.scrumble.domain.todo.domain.QSquadToDo.*;
 
@@ -9,8 +10,8 @@ import org.springframework.stereotype.Repository;
 
 import com.eggmeonina.scrumble.domain.todo.dto.QSquadTodoResponse;
 import com.eggmeonina.scrumble.domain.todo.dto.SquadTodoRequest;
-import com.eggmeonina.scrumble.domain.todo.repository.SquadTodoRepositoryCustom;
 import com.eggmeonina.scrumble.domain.todo.dto.SquadTodoResponse;
+import com.eggmeonina.scrumble.domain.todo.repository.SquadTodoRepositoryCustom;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import lombok.RequiredArgsConstructor;
@@ -24,12 +25,14 @@ public class SquadTodoRepositoryCustomImpl implements SquadTodoRepositoryCustom 
 	public List<SquadTodoResponse> findSquadTodos(Long squadMemberId, SquadTodoRequest request) {
 		return query.select(
 				new QSquadTodoResponse(squadToDo.toDo.id, squadToDo.id, squadToDo.toDo.contents, squadToDo.toDo.toDoAt,
-					squadToDo.toDo.toDoStatus)
+					squadToDo.toDo.toDoStatus, category.id, category.categoryName, category.color)
 			)
 			.from(squadMember)
 			.join(squadToDo)
 			.on(squadMember.squad.id.eq(squadToDo.squad.id)
 				.and(squadMember.member.id.eq(squadToDo.toDo.member.id)))
+			.leftJoin(category)
+			.on(category.id.eq(squadToDo.toDo.categoryId))
 			.where(squadMember.id.eq(squadMemberId)
 				.and(squadToDo.toDo.id.gt(request.getLastToDoId()))
 				.and(squadToDo.deletedFlag.eq(false))

--- a/src/main/java/com/eggmeonina/scrumble/domain/todo/repository/impl/ToDoRepositoryCustomImpl.java
+++ b/src/main/java/com/eggmeonina/scrumble/domain/todo/repository/impl/ToDoRepositoryCustomImpl.java
@@ -1,5 +1,6 @@
 package com.eggmeonina.scrumble.domain.todo.repository.impl;
 
+import static com.eggmeonina.scrumble.domain.category.domain.QCategory.*;
 import static com.eggmeonina.scrumble.domain.squadmember.domain.QSquad.*;
 import static com.eggmeonina.scrumble.domain.todo.domain.QSquadToDo.*;
 import static com.eggmeonina.scrumble.domain.todo.domain.QToDo.*;
@@ -34,6 +35,8 @@ public class ToDoRepositoryCustomImpl implements ToDoRepositoryCustom {
 				.and(squadToDo.deletedFlag.eq(false)))
 			.join(squad)
 			.on(squad.id.eq(squadToDo.squad.id))
+			.leftJoin(category)
+			.on(category.id.eq(toDo.categoryId))
 			.where(toDo.id.gt(request.getLastToDoId())
 			.and(toDo.member.id.eq(memberId))
 				.and(toDo.toDoAt.between(request.getStartDate(), request.getEndDate()))
@@ -43,7 +46,8 @@ public class ToDoRepositoryCustomImpl implements ToDoRepositoryCustom {
 			.transform(
 				groupBy(toDo.toDoAt).list(
 					new QToDoResponse(toDo.toDoAt, list(
-						new QToDoDetailResponse(toDo.id, squad.id, squad.squadName, toDo.contents, toDo.toDoAt, toDo.toDoStatus)
+						new QToDoDetailResponse(toDo.id, squad.id, squad.squadName, toDo.contents, toDo.toDoAt, toDo.toDoStatus, category.id,
+							category.categoryName, category.color)
 					))
 				)
 			);

--- a/src/main/java/com/eggmeonina/scrumble/domain/todo/service/ToDoService.java
+++ b/src/main/java/com/eggmeonina/scrumble/domain/todo/service/ToDoService.java
@@ -58,7 +58,7 @@ public class ToDoService {
 		}
 		ToDo foundToDo = todoRepository.findByIdAndDeletedFlagNot(toDoId)
 			.orElseThrow(() -> new ToDoException(TODO_NOT_FOUND));
-		foundToDo.update(request.getContents(), request.getToDoStatus(), request.getToDoAt());
+		foundToDo.update(request.getContents(), request.getToDoStatus(), request.getToDoAt(), request.getCategoryId());
 		return ToDoCommandResponse.to(foundToDo);
 	}
 

--- a/src/main/resources/db/h2/schema.sql
+++ b/src/main/resources/db/h2/schema.sql
@@ -78,6 +78,7 @@ CREATE TABLE todo
     todo_at      DATE        NOT NULL,
     deleted_flag TINYINT     NOT NULL,
     member_id    BIGINT      NOT NULL,
+    category_id  BIGINT      NULL,
     created_at   TIMESTAMP   NULL,
     updated_at   TIMESTAMP   NULL,
     PRIMARY KEY (todo_id)

--- a/src/main/resources/db/mysql/schema.sql
+++ b/src/main/resources/db/mysql/schema.sql
@@ -76,6 +76,7 @@ CREATE TABLE todo
     todo_at      date        NOT NULL COMMENT '투두 실행일',
     deleted_flag tinyint     NOT NULL DEFAULT 0,
     member_id    bigint      NOT NULL COMMENT '작성자',
+    category_id  bigint      NULL,
     created_at   datetime    NULL,
     updated_at   datetime    NULL
 );

--- a/src/test/java/com/eggmeonina/scrumble/domain/todo/domain/ToDoTest.java
+++ b/src/test/java/com/eggmeonina/scrumble/domain/todo/domain/ToDoTest.java
@@ -42,7 +42,7 @@ class ToDoTest {
 		ToDoStatus newToDoStatus = ToDoStatus.COMPLETED;
 
 		// when
-		newToDo.update(newContents, newToDoStatus, newToDo.getToDoAt());
+		newToDo.update(newContents, newToDoStatus, newToDo.getToDoAt(), 1L);
 
 		// then
 		assertThat(newToDo.getToDoStatus()).isEqualTo(newToDoStatus);

--- a/src/test/java/com/eggmeonina/scrumble/domain/todo/facade/SquadToDoFacadeServiceIntegrationTest.java
+++ b/src/test/java/com/eggmeonina/scrumble/domain/todo/facade/SquadToDoFacadeServiceIntegrationTest.java
@@ -14,6 +14,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import com.eggmeonina.scrumble.common.exception.MemberException;
 import com.eggmeonina.scrumble.common.exception.SquadException;
 import com.eggmeonina.scrumble.common.exception.ToDoException;
+import com.eggmeonina.scrumble.domain.category.repository.CategoryRepository;
 import com.eggmeonina.scrumble.domain.member.domain.Member;
 import com.eggmeonina.scrumble.domain.member.domain.MemberStatus;
 import com.eggmeonina.scrumble.domain.member.repository.MemberRepository;
@@ -27,6 +28,7 @@ import com.eggmeonina.scrumble.domain.todo.dto.SquadTodoCreateRequest;
 import com.eggmeonina.scrumble.domain.todo.dto.ToDoCommandResponse;
 import com.eggmeonina.scrumble.domain.todo.repository.SquadTodoRepository;
 import com.eggmeonina.scrumble.domain.todo.repository.TodoRepository;
+import com.eggmeonina.scrumble.fixture.CategoryFixture;
 import com.eggmeonina.scrumble.helper.IntegrationTestHelper;
 
 class SquadToDoFacadeServiceIntegrationTest extends IntegrationTestHelper {
@@ -46,6 +48,9 @@ class SquadToDoFacadeServiceIntegrationTest extends IntegrationTestHelper {
 	@Autowired
 	private TodoRepository todoRepository;
 
+	@Autowired
+	private CategoryRepository categoryRepository;
+
 	@Test
 	@DisplayName("스쿼드가 존재하지 않는 투두를 등록한다_실패")
 	void createToDoWhenNotExistsSquad_fail() {
@@ -56,7 +61,10 @@ class SquadToDoFacadeServiceIntegrationTest extends IntegrationTestHelper {
 		memberRepository.save(newMember);
 		squadRepository.save(newSquad);
 
-		SquadTodoCreateRequest request = new SquadTodoCreateRequest(ToDoType.DAILY, "테스트 작성하기", LocalDate.now());
+		var newCategory = CategoryFixture.createCategory(newMember.getId());
+		categoryRepository.save(newCategory);
+
+		SquadTodoCreateRequest request = new SquadTodoCreateRequest(ToDoType.DAILY, "테스트 작성하기", LocalDate.now(), newCategory.getId());
 
 		// when, then
 		assertThatThrownBy(
@@ -77,7 +85,10 @@ class SquadToDoFacadeServiceIntegrationTest extends IntegrationTestHelper {
 		memberRepository.save(newMember);
 		squadRepository.save(newSquad);
 
-		SquadTodoCreateRequest request = new SquadTodoCreateRequest(ToDoType.DAILY, "테스트 작성하기", LocalDate.now());
+		var newCategory = CategoryFixture.createCategory(newMember.getId());
+		categoryRepository.save(newCategory);
+
+		SquadTodoCreateRequest request = new SquadTodoCreateRequest(ToDoType.DAILY, "테스트 작성하기", LocalDate.now(), newCategory.getId());
 
 		// when
 		ToDoCommandResponse response = squadToDoFacadeService.createToDoAndSquadToDo(newSquad.getId(),
@@ -103,7 +114,10 @@ class SquadToDoFacadeServiceIntegrationTest extends IntegrationTestHelper {
 		memberRepository.save(newMember);
 		squadRepository.save(newSquad);
 
-		SquadTodoCreateRequest request = new SquadTodoCreateRequest(ToDoType.DAILY, "테스트 작성하기", LocalDate.now());
+		var newCategory = CategoryFixture.createCategory(newMember.getId());
+		categoryRepository.save(newCategory);
+
+		SquadTodoCreateRequest request = new SquadTodoCreateRequest(ToDoType.DAILY, "테스트 작성하기", LocalDate.now(), newCategory.getId());
 
 		// when, then
 		assertThatThrownBy(

--- a/src/test/java/com/eggmeonina/scrumble/domain/todo/service/ToDoServiceTest.java
+++ b/src/test/java/com/eggmeonina/scrumble/domain/todo/service/ToDoServiceTest.java
@@ -43,7 +43,7 @@ class ToDoServiceTest {
 	void createToDo_success() {
 		// given
 		Member newMember = createMember("testA", "test@test.com", MemberStatus.JOIN, "1234564");
-		SquadTodoCreateRequest request = new SquadTodoCreateRequest(ToDoType.DAILY, "오늘의 할 일", LocalDate.now());
+		SquadTodoCreateRequest request = new SquadTodoCreateRequest(ToDoType.DAILY, "오늘의 할 일", LocalDate.now(), 1L);
 
 		given(memberRepository.findByIdAndMemberStatusNotJOIN(anyLong())).willReturn(Optional.ofNullable(newMember));
 
@@ -58,7 +58,7 @@ class ToDoServiceTest {
 	@DisplayName("탈퇴한 회원이 투두를 등록한다_실패")
 	void createToDoWhenWithdrawMember_fail() {
 		// given
-		SquadTodoCreateRequest request = new SquadTodoCreateRequest(ToDoType.DAILY, "오늘의 할 일", LocalDate.now());
+		SquadTodoCreateRequest request = new SquadTodoCreateRequest(ToDoType.DAILY, "오늘의 할 일", LocalDate.now(), 1L);
 
 		given(memberRepository.findByIdAndMemberStatusNotJOIN(anyLong())).willReturn(Optional.empty());
 
@@ -105,7 +105,7 @@ class ToDoServiceTest {
 		Member newMember = createMember("userA", "test@test.com", MemberStatus.JOIN, "!2234235");
 		ToDo newToDo = createToDo(newMember, "모각코", ToDoStatus.PENDING, false, LocalDate.now());
 
-		ToDoUpdateRequest request = new ToDoUpdateRequest("수정된 투두 내용", ToDoStatus.COMPLETED, LocalDate.now());
+		ToDoUpdateRequest request = new ToDoUpdateRequest("수정된 투두 내용", ToDoStatus.COMPLETED, LocalDate.now(), 1L);
 
 		given(todoRepository.existsByIdAndMemberId(anyLong(), anyLong()))
 			.willReturn(true);
@@ -127,7 +127,7 @@ class ToDoServiceTest {
 	@DisplayName("삭제된 투두를 수정한다_실패")
 	void updateToDoWhenDeletedToDo_fail() {
 		// given
-		ToDoUpdateRequest request = new ToDoUpdateRequest("수정된 투두 내용", ToDoStatus.COMPLETED, LocalDate.now());
+		ToDoUpdateRequest request = new ToDoUpdateRequest("수정된 투두 내용", ToDoStatus.COMPLETED, LocalDate.now(), 1L);
 
 		given(todoRepository.existsByIdAndMemberId(anyLong(), anyLong()))
 			.willReturn(true);
@@ -144,7 +144,7 @@ class ToDoServiceTest {
 	@DisplayName("작성자가 아닌 회원이 투두를 수정한다_실패")
 	void updateToDoWhenIsNotWriter_fail() {
 		// given
-		ToDoUpdateRequest request = new ToDoUpdateRequest("수정된 투두 내용", ToDoStatus.COMPLETED, LocalDate.now());
+		ToDoUpdateRequest request = new ToDoUpdateRequest("수정된 투두 내용", ToDoStatus.COMPLETED, LocalDate.now(), 1L);
 
 		given(todoRepository.existsByIdAndMemberId(anyLong(), anyLong()))
 			.willReturn(false);


### PR DESCRIPTION
## 관련 이슈
#326 

## 작업 사항
<!-- 가장 대표적인 작업 내용 -->
투두 도메인에 카테고리 id 컬럼을 추가했습니다. 다만, 카테고리를 등록하지 않았던 유저가 존재할 수 있기 때문에 nullable하게 관리합니다.
이로 인해 투두 조회, 수정, 생성 시에도 카테고리 Id 항목을 추가하였습니다.
스쿼드 투두 조회, 나의 투두 조회 시에는 카테고리명, 카테고리 색상도 함께 조회됩니다.
투두와 카테고리는 별도의 싸이클을 갖고 있는 관계로 투두 도메인에 categoryId로 관리합니다.

### 스크린샷 (해당되는 경우)
<!-- UI 변경 사항이 있는 경우, 스크린샷을 첨부해주세요. -->

### 추가 정보
<!-- 이 PR에 대한 추가적인 정보가 필요하다면 작성해주세요. -->
